### PR TITLE
채팅 기능(Kafka/WebSocket) 및 스마일서브 서버 이전 반영

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -64,14 +64,14 @@ jobs:
                   COMMIT_SHA: ${{ github.sha }}
               run: |
                   echo "🚀 Starting deployment to production server..."
-                  ssh -i ~/.ssh/prod_key -o StrictHostKeyChecking=no root@${{ secrets.PROD_SERVER_HOST }} << ENDSSH > deploy.log 2>&1
+                  ssh -i ~/.ssh/prod_key -o StrictHostKeyChecking=no colding@${{ secrets.PROD_SERVER_HOST }} << ENDSSH > deploy.log 2>&1
                   set -e
 
                   echo "📦 Authenticating with Artifact Registry..."
-                  gcloud auth activate-service-account --key-file=/root/gcp-service-account.json
+                  gcloud auth activate-service-account --key-file=/home/colding/gcp-service-account.json
                   gcloud auth configure-docker ${GAR_LOCATION} --quiet
 
-                  cd /root/pawpong_backend || { echo "❌ Directory not found"; exit 1; }
+                  cd /home/colding/pawpong_backend || { echo "❌ Directory not found"; exit 1; }
 
                   echo "📥 Pulling latest code..."
                   git pull origin main
@@ -114,7 +114,7 @@ jobs:
                            \"description\": \"Main 브랜치가 프로덕션 서버에 성공적으로 배포되었습니다.\",
                            \"color\": 3066993,
                            \"fields\": [
-                             {\"name\": \"서버\", \"value\": \"115.68.176.129\", \"inline\": true},
+                             {\"name\": \"서버\", \"value\": \"${{ secrets.PROD_SERVER_HOST }}\", \"inline\": true},
                              {\"name\": \"배포 방식\", \"value\": \"Docker Blue-Green\", \"inline\": true},
                              {\"name\": \"활성 컨테이너\", \"value\": \"${ACTIVE_CONTAINER} (포트 ${ACTIVE_PORT})\", \"inline\": true},
                              {\"name\": \"커밋 SHA\", \"value\": \"$COMMIT_SHA\", \"inline\": true},
@@ -155,7 +155,7 @@ jobs:
                            \"description\": \"Main 브랜치 배포 중 오류가 발생했습니다. ${FAIL_INFO}\",
                            \"color\": 15158332,
                            \"fields\": [
-                             {\"name\": \"서버\", \"value\": \"115.68.176.129\", \"inline\": true},
+                             {\"name\": \"서버\", \"value\": \"${{ secrets.PROD_SERVER_HOST }}\", \"inline\": true},
                              {\"name\": \"배포 방식\", \"value\": \"Docker Blue-Green\", \"inline\": true},
                              {\"name\": \"커밋 SHA\", \"value\": \"$COMMIT_SHA\", \"inline\": true},
                              {\"name\": \"커밋 작성자\", \"value\": \"$COMMIT_AUTHOR\", \"inline\": true},

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,17 +33,17 @@ echo -e "${BLUE}========================================${NC}"
 # 배포 시작 알림
 send_discord_notification "배포 시작\nTag: \`$IMAGE_TAG\`" 16776960
 
-cd /root/pawpong_backend
+cd /home/colding/pawpong_backend
 
 # 이전 이미지 태그 저장 (롤백용)
 LAST_IMAGE=$(docker images pawpong-backend --format "{{.Tag}}" | head -n 1)
-echo "$LAST_IMAGE" > /root/pawpong_backend/.last_deploy
+echo "$LAST_IMAGE" > /home/colding/pawpong_backend/.last_deploy
 echo -e "${YELLOW}Previous image tag saved: ${LAST_IMAGE}${NC}"
 
 # 배포 히스토리 저장 (최근 10개 유지)
-echo "$IMAGE_TAG" >> /root/pawpong_backend/.deploy_history
-tail -10 /root/pawpong_backend/.deploy_history > /root/pawpong_backend/.deploy_history.tmp
-mv /root/pawpong_backend/.deploy_history.tmp /root/pawpong_backend/.deploy_history
+echo "$IMAGE_TAG" >> /home/colding/pawpong_backend/.deploy_history
+tail -10 /home/colding/pawpong_backend/.deploy_history > /home/colding/pawpong_backend/.deploy_history.tmp
+mv /home/colding/pawpong_backend/.deploy_history.tmp /home/colding/pawpong_backend/.deploy_history
 echo -e "${YELLOW}Deployment history updated${NC}"
 
 echo -e "${BLUE}Using Docker image from Artifact Registry: pawpong-backend:latest${NC}"

--- a/rollback.sh
+++ b/rollback.sh
@@ -13,7 +13,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-cd /root/pawpong_backend
+cd /home/colding/pawpong_backend
 
 echo -e "${BLUE}========================================${NC}"
 echo -e "${BLUE}Pawpong Backend Rollback${NC}"


### PR DESCRIPTION
## Summary
- Kafka + WebSocket 기반 실시간 채팅 기능 구현 (채팅방 생성, 메시지 전송, 읽음 처리)
- 헥사고날/DDD 아키텍처 적용 (chat 도메인)
- 입양 신청서 일부 필드 optional로 변경
- 앱 버전 관리 API 추가
- 스마일서브 서버 이전에 따른 배포 스크립트 경로 및 SSH 설정 수정
  - `/root/pawpong_backend` → `/home/colding/pawpong_backend`
  - SSH 유저 `root` → `colding`
  - 디스코드 알림 IP 하드코딩 제거 → `secrets.PROD_SERVER_HOST`

## 배포 전 준비사항
- [x] prod DB 백업 (mongodump, 2026-04-12)
- [x] 프로덕션 서버 Kafka 인프라 실행 (`docker compose --profile kafka up -d`)
- [x] 서버 경로 확인 및 배포 스크립트 수정
- [ ] GitHub Secrets에 새 서버 IP 반영 확인 (팀원 처리 예정)

## Test plan
- 채팅 E2E 테스트 통과 확인
- 배포 후 `docker ps`로 Kafka/앱 컨테이너 상태 확인
- 배포 후 기존 기능(로그인, 브리더 조회 등) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)