### PR TITLE
feat: 관리자 대시보드 서버 현황 페이지 API 구현 (GET /api/platform-admin/system-health)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 CLAUDE.md
 swagger.json
+
+# MCP server config (local dev tool, machine-specific)
+.mcp.json
 package-lock.json
 yarn.lock
 docs/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "pawpong_backend"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/scripts/create-admin.ts
+++ b/scripts/create-admin.ts
@@ -1,0 +1,98 @@
+/**
+ * 관리자 계정 생성 스크립트
+ *
+ * 사용법: yarn create:admin
+ *
+ * .env의 MONGODB_URI에 연결하여 관리자 계정을 생성합니다.
+ * dev DB 또는 로컬 DB 대상으로만 사용하세요.
+ */
+import * as readline from 'readline';
+import * as mongoose from 'mongoose';
+import * as bcrypt from 'bcryptjs';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+// .env 로드
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) {
+    console.error('❌ MONGODB_URI가 .env에 없습니다.');
+    process.exit(1);
+}
+
+const AdminSchema = new mongoose.Schema(
+    {
+        name: String,
+        email: { type: String, unique: true },
+        password: String,
+        status: { type: String, default: 'active' },
+        adminLevel: { type: String, default: 'super_admin' },
+        permissions: {
+            canManageUsers: { type: Boolean, default: true },
+            canManageBreeders: { type: Boolean, default: true },
+            canManageReports: { type: Boolean, default: true },
+            canViewStatistics: { type: Boolean, default: true },
+            canManageAdmins: { type: Boolean, default: true },
+        },
+        activityLogs: { type: Array, default: [] },
+    },
+    { timestamps: true },
+);
+
+function prompt(question: string): Promise<string> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
+}
+
+async function main() {
+    console.log('\n=== Pawpong 관리자 계정 생성 ===');
+    console.log(`📦 DB: ${MONGODB_URI!.replace(/\/\/.*@/, '//****@')}\n`);
+
+    const name = await prompt('이름: ');
+    const email = await prompt('이메일: ');
+    const password = await prompt('비밀번호: ');
+
+    if (!name || !email || !password) {
+        console.error('❌ 모든 항목을 입력해야 합니다.');
+        process.exit(1);
+    }
+
+    await mongoose.connect(MONGODB_URI!);
+
+    const AdminModel = mongoose.model('Admin', AdminSchema);
+
+    const existing = await AdminModel.findOne({ email });
+    if (existing) {
+        console.error(`❌ ${email} 계정이 이미 존재합니다.`);
+        await mongoose.disconnect();
+        process.exit(1);
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    await AdminModel.create({
+        name,
+        email,
+        password: hashedPassword,
+    });
+
+    console.log(`\n✅ 관리자 계정 생성 완료!`);
+    console.log(`   이름: ${name}`);
+    console.log(`   이메일: ${email}`);
+    console.log(`   권한: super_admin (전체)\n`);
+
+    await mongoose.disconnect();
+    process.exit(0);
+}
+
+main().catch((err) => {
+    console.error('❌ 오류 발생:', err.message);
+    process.exit(1);
+});

--- a/src/api/platform/admin/application/ports/loki-query.port.ts
+++ b/src/api/platform/admin/application/ports/loki-query.port.ts
@@ -1,0 +1,50 @@
+/**
+ * Loki 로그 쿼리 Port
+ *
+ * 로그 수집 인프라(Loki)와의 경계를 정의합니다.
+ * Adapter가 이 인터페이스를 구현하여 실제 HTTP 통신을 담당합니다.
+ */
+export const LOKI_QUERY_PORT = Symbol('LOKI_QUERY_PORT');
+
+/**
+ * Loki에서 파싱된 단일 로그 항목
+ */
+export interface LokiLogEntry {
+    /** Winston JSON의 timestamp 필드 (ISO 8601) */
+    timestamp: string;
+    /** 로그 레벨 (error | warn | info | debug) */
+    level: string;
+    /** NestJS 컨텍스트 (클래스명 또는 모듈명) */
+    context: string;
+    /** 로그 메시지 본문 */
+    message: string;
+    /** blue | green */
+    deployment: string;
+}
+
+/**
+ * queryErrorsAndWarnings 호출 옵션
+ */
+export interface LokiQueryOptions {
+    /** 조회 시작 시간 (ISO 8601) */
+    from: string;
+    /** 조회 종료 시간 (ISO 8601) */
+    to: string;
+    /** 최대 조회 건수 (기본 1000) */
+    limit: number;
+}
+
+/**
+ * Loki 쿼리 Port 인터페이스
+ */
+export interface ILokiQueryPort {
+    /**
+     * 지정 기간의 error/warn 레벨 로그를 전부 조회합니다.
+     */
+    queryErrorsAndWarnings(options: LokiQueryOptions): Promise<LokiLogEntry[]>;
+
+    /**
+     * Loki 서비스 가용 여부를 확인합니다.
+     */
+    isAvailable(): Promise<boolean>;
+}

--- a/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
+++ b/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
@@ -31,21 +31,25 @@ export class GetSystemHealthUseCase {
      *
      * @param adminId 요청한 관리자 ID
      * @param filter 기간 필터 (기본 24시간)
+     * @param now 기준 시각 — 컨트롤러에서 주입하여 응답의 period와 Loki 쿼리 범위를 일치시킵니다.
      * @returns 분류된 시스템 헬스 요약
      */
-    async execute(adminId: string, filter: SystemHealthFilterRequestDto): Promise<CategorizationResult> {
+    async execute(
+        adminId: string,
+        filter: SystemHealthFilterRequestDto,
+        now: Date = new Date(),
+    ): Promise<CategorizationResult> {
         await this.verifyAdminPermission(adminId);
 
-        const now = new Date();
         const periodHours = filter.periodHours ?? 24;
         const from = new Date(now.getTime() - periodHours * 60 * 60 * 1000).toISOString();
         const to = now.toISOString();
 
-        const entries = await this.lokiQueryPort.queryErrorsAndWarnings({
-            from,
-            to,
-            limit: 1000,
-        });
+        // 조회 기간이 길수록 더 많은 로그가 필요하므로 limit을 동적으로 산정합니다.
+        // 최소 1000건 / 최대 5000건 (Loki 부하 고려)
+        const limit = Math.min(5000, Math.max(1000, periodHours * 100));
+
+        const entries = await this.lokiQueryPort.queryErrorsAndWarnings({ from, to, limit });
 
         return this.logCategorizerService.categorize(entries, now);
     }

--- a/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
+++ b/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
@@ -1,0 +1,62 @@
+import { Injectable, Inject, ForbiddenException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { Admin, AdminDocument } from '../../../../../schema/admin.schema';
+import { LOKI_QUERY_PORT } from '../ports/loki-query.port';
+import type { ILokiQueryPort } from '../ports/loki-query.port';
+import { LogCategorizerService } from '../../domain/services/log-categorizer.service';
+import type { CategorizationResult } from '../../domain/services/log-categorizer.service';
+import { SystemHealthFilterRequestDto } from '../../dto/request/system-health-filter-request.dto';
+
+/**
+ * 시스템 헬스 조회 Use Case
+ *
+ * 오케스트레이션 책임:
+ * 1. 관리자 권한 확인
+ * 2. Loki에서 error/warn 로그 조회 (Port 경유)
+ * 3. Domain Service로 분류 및 그룹핑
+ * 4. 결과 반환
+ */
+@Injectable()
+export class GetSystemHealthUseCase {
+    constructor(
+        @InjectModel(Admin.name) private readonly adminModel: Model<AdminDocument>,
+        @Inject(LOKI_QUERY_PORT) private readonly lokiQueryPort: ILokiQueryPort,
+        private readonly logCategorizerService: LogCategorizerService,
+    ) {}
+
+    /**
+     * 시스템 헬스 데이터를 조회합니다.
+     *
+     * @param adminId 요청한 관리자 ID
+     * @param filter 기간 필터 (기본 24시간)
+     * @returns 분류된 시스템 헬스 요약
+     */
+    async execute(adminId: string, filter: SystemHealthFilterRequestDto): Promise<CategorizationResult> {
+        await this.verifyAdminPermission(adminId);
+
+        const now = new Date();
+        const periodHours = filter.periodHours ?? 24;
+        const from = new Date(now.getTime() - periodHours * 60 * 60 * 1000).toISOString();
+        const to = now.toISOString();
+
+        const entries = await this.lokiQueryPort.queryErrorsAndWarnings({
+            from,
+            to,
+            limit: 1000,
+        });
+
+        return this.logCategorizerService.categorize(entries, now);
+    }
+
+    /**
+     * 관리자 통계 조회 권한을 확인합니다.
+     */
+    private async verifyAdminPermission(adminId: string): Promise<void> {
+        const admin = await this.adminModel.findById(adminId).lean();
+        if (!admin || !admin.permissions.canViewStatistics) {
+            throw new ForbiddenException('시스템 헬스 조회 권한이 없습니다.');
+        }
+    }
+}

--- a/src/api/platform/admin/domain/services/log-categorizer.service.ts
+++ b/src/api/platform/admin/domain/services/log-categorizer.service.ts
@@ -78,6 +78,19 @@ export class LogCategorizerService {
     private static readonly ACTIVE_ERROR_THRESHOLD_MS = 60 * 60 * 1000;
 
     /**
+     * Redis 관련 NestJS 컨텍스트 이름 목록.
+     * ioredis, @nestjs/cache-manager, nestjs-redis 등에서 발생하는
+     * 연결 에러 컨텍스트를 포괄합니다.
+     */
+    private static readonly REDIS_CONTEXTS = new Set([
+        'IoRedis',
+        'Redis',
+        'RedisModule',
+        'RedisService',
+        'CacheManager',
+    ]);
+
+    /**
      * 로그 항목 배열을 분류하여 시스템 헬스 요약을 반환합니다.
      *
      * @param entries Loki에서 가져온 로그 항목 배열
@@ -143,12 +156,20 @@ export class LogCategorizerService {
      *
      * 분류 규칙:
      * - ServerKafka 컨텍스트 → infrastructure
+     * - Redis 관련 컨텍스트 (IoRedis, RedisService 등) → infrastructure
      * - HttpExceptionFilter + /api/ 미포함 경로 → security_probe (봇 스캔)
      * - HttpExceptionFilter + /api/ 포함 경로 → api_error
      * - 그 외 → application
      */
     private classifyCategory(entry: LokiLogEntry): IssueCategory {
         if (entry.context === 'ServerKafka') {
+            return 'infrastructure';
+        }
+
+        if (
+            LogCategorizerService.REDIS_CONTEXTS.has(entry.context) ||
+            /redis/i.test(entry.context)
+        ) {
             return 'infrastructure';
         }
 
@@ -163,7 +184,8 @@ export class LogCategorizerService {
     /**
      * 그룹 키를 생성합니다.
      *
-     * - infrastructure: context 기준 (Kafka 에러 전체를 하나로 묶음)
+     * - infrastructure(Kafka): infrastructure:ServerKafka
+     * - infrastructure(Redis): infrastructure:Redis (컨텍스트 이름 관계없이 단일 키로 정규화)
      * - security_probe: 단일 그룹
      * - api_error: context 기준
      * - application: context 기준
@@ -171,7 +193,10 @@ export class LogCategorizerService {
     private buildGroupKey(entry: LokiLogEntry, category: IssueCategory): string {
         switch (category) {
             case 'infrastructure':
-                return `infrastructure:${entry.context}`;
+                if (entry.context === 'ServerKafka') return 'infrastructure:ServerKafka';
+                // Redis 관련 컨텍스트는 구현 라이브러리(IoRedis, RedisModule 등)가 달라도
+                // 하나의 그룹으로 묶어 서비스 단위 모니터링이 가능하도록 정규화합니다.
+                return 'infrastructure:Redis';
             case 'security_probe':
                 return 'security_probe';
             case 'api_error':
@@ -196,6 +221,7 @@ export class LogCategorizerService {
     private getTitle(groupKey: string, category: IssueCategory): string {
         const titleMap: Record<string, string> = {
             'infrastructure:ServerKafka': '채팅 서버 (Kafka) 연결 오류',
+            'infrastructure:Redis': 'Redis 캐시 서버 연결 오류',
             security_probe: '외부 자동화 스캔 감지',
         };
 
@@ -211,6 +237,7 @@ export class LogCategorizerService {
     private getDescription(groupKey: string, category: IssueCategory): string {
         const descMap: Record<string, string> = {
             'infrastructure:ServerKafka': '채팅 메시지 전송에 영향이 있을 수 있습니다.',
+            'infrastructure:Redis': '로그인 세션, 캐시 등 Redis 의존 기능에 영향이 있을 수 있습니다.',
             security_probe: '알 수 없는 외부 봇이 서버를 스캔했습니다. 서비스에는 영향이 없습니다.',
         };
 
@@ -224,8 +251,8 @@ export class LogCategorizerService {
      */
     private determineServiceHealth(groups: IssueGroup[], now: Date): ServiceHealthInfo {
         const kafkaGroup = groups.find((g) => g.groupKey === 'infrastructure:ServerKafka');
+        const redisGroup = groups.find((g) => g.groupKey === 'infrastructure:Redis');
         const apiGroup = groups.find((g) => g.category === 'api_error');
-        const redisGroup = groups.find((g) => g.groupKey.includes('Redis') || g.groupKey.includes('redis'));
 
         return {
             kafka: this.buildServiceStatus(kafkaGroup, now),

--- a/src/api/platform/admin/domain/services/log-categorizer.service.ts
+++ b/src/api/platform/admin/domain/services/log-categorizer.service.ts
@@ -1,0 +1,286 @@
+import { Injectable } from '@nestjs/common';
+
+import { LokiLogEntry } from '../../application/ports/loki-query.port';
+
+/** 이슈 분류 카테고리 */
+export type IssueCategory = 'infrastructure' | 'api_error' | 'security_probe' | 'application';
+
+/** 이슈 심각도 */
+export type IssueSeverity = 'critical' | 'warning' | 'info';
+
+/** 서비스 상태 */
+export type ServiceStatus = 'healthy' | 'warning' | 'error' | 'unknown';
+
+/** 전체 시스템 상태 */
+export type OverallStatus = 'healthy' | 'warning' | 'critical';
+
+/**
+ * 이슈 그룹 — 동일한 원인의 로그를 묶은 단위
+ */
+export interface IssueGroup {
+    /** 그룹 식별 키 (내부용) */
+    groupKey: string;
+    /** 이슈 카테고리 */
+    category: IssueCategory;
+    /** 심각도 */
+    severity: IssueSeverity;
+    /** PM이 읽는 제목 (한국어) */
+    title: string;
+    /** PM이 읽는 설명 (한국어) */
+    description: string;
+    /** 발생 횟수 */
+    count: number;
+    /** 최초 발생 시각 (ISO 8601) */
+    firstAt: string;
+    /** 최근 발생 시각 (ISO 8601) */
+    lastAt: string;
+    /** 30분 이상 재발 없으면 해결된 것으로 판단 */
+    isResolved: boolean;
+}
+
+/**
+ * 서비스별 상태
+ */
+export interface ServiceHealthInfo {
+    /** 채팅 서버 (Kafka) 상태 */
+    kafka: { status: ServiceStatus; lastErrorAt: string | null };
+    /** Redis 상태 */
+    redis: { status: ServiceStatus; lastErrorAt: string | null };
+    /** API 서버 상태 */
+    api: { status: ServiceStatus; lastErrorAt: string | null };
+}
+
+/**
+ * 분류 결과
+ */
+export interface CategorizationResult {
+    overallStatus: OverallStatus;
+    services: ServiceHealthInfo;
+    summary: { critical: number; warning: number; info: number };
+    issueGroups: IssueGroup[];
+}
+
+/**
+ * 로그 분류 Domain Service
+ *
+ * 순수 비즈니스 규칙만 담당합니다:
+ * - 로그 항목을 카테고리/심각도로 분류
+ * - 동일 원인의 로그를 그룹핑
+ * - 서비스별 상태 판정
+ * - 전체 상태 판정
+ */
+@Injectable()
+export class LogCategorizerService {
+    /** 30분 경과 시 "해결됨"으로 판단 */
+    private static readonly RESOLVED_THRESHOLD_MS = 30 * 60 * 1000;
+
+    /** 1시간 이내 에러 = error 상태 */
+    private static readonly ACTIVE_ERROR_THRESHOLD_MS = 60 * 60 * 1000;
+
+    /**
+     * 로그 항목 배열을 분류하여 시스템 헬스 요약을 반환합니다.
+     *
+     * @param entries Loki에서 가져온 로그 항목 배열
+     * @param now 현재 시각 (테스트 주입 가능)
+     */
+    categorize(entries: LokiLogEntry[], now: Date = new Date()): CategorizationResult {
+        const groups = this.buildIssueGroups(entries, now);
+        const services = this.determineServiceHealth(groups, now);
+        const overallStatus = this.determineOverallStatus(groups);
+        const summary = this.buildSummary(groups);
+
+        return { overallStatus, services, summary, issueGroups: groups };
+    }
+
+    // ─────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────
+
+    /**
+     * 로그 항목을 카테고리별로 그룹핑합니다.
+     */
+    private buildIssueGroups(entries: LokiLogEntry[], now: Date): IssueGroup[] {
+        const groupMap = new Map<string, { entries: LokiLogEntry[]; category: IssueCategory }>();
+
+        for (const entry of entries) {
+            const category = this.classifyCategory(entry);
+            const groupKey = this.buildGroupKey(entry, category);
+
+            if (!groupMap.has(groupKey)) {
+                groupMap.set(groupKey, { entries: [], category });
+            }
+            groupMap.get(groupKey)!.entries.push(entry);
+        }
+
+        const groups: IssueGroup[] = [];
+
+        for (const [groupKey, { entries: groupEntries, category }] of groupMap.entries()) {
+            const timestamps = groupEntries.map((e) => new Date(e.timestamp).getTime());
+            const firstAt = new Date(Math.min(...timestamps)).toISOString();
+            const lastAt = new Date(Math.max(...timestamps)).toISOString();
+            const isResolved = now.getTime() - Math.max(...timestamps) > LogCategorizerService.RESOLVED_THRESHOLD_MS;
+            const severity = this.determineSeverity(category, isResolved);
+
+            groups.push({
+                groupKey,
+                category,
+                severity,
+                title: this.getTitle(groupKey, category),
+                description: this.getDescription(groupKey, category),
+                count: groupEntries.length,
+                firstAt,
+                lastAt,
+                isResolved,
+            });
+        }
+
+        // 최근 발생 순 정렬
+        return groups.sort((a, b) => new Date(b.lastAt).getTime() - new Date(a.lastAt).getTime());
+    }
+
+    /**
+     * 로그 항목 하나를 카테고리로 분류합니다.
+     *
+     * 분류 규칙:
+     * - ServerKafka 컨텍스트 → infrastructure
+     * - HttpExceptionFilter + /api/ 미포함 경로 → security_probe (봇 스캔)
+     * - HttpExceptionFilter + /api/ 포함 경로 → api_error
+     * - 그 외 → application
+     */
+    private classifyCategory(entry: LokiLogEntry): IssueCategory {
+        if (entry.context === 'ServerKafka') {
+            return 'infrastructure';
+        }
+
+        if (entry.context === 'HttpExceptionFilter') {
+            const isApiPath = /\/api\//.test(entry.message);
+            return isApiPath ? 'api_error' : 'security_probe';
+        }
+
+        return 'application';
+    }
+
+    /**
+     * 그룹 키를 생성합니다.
+     *
+     * - infrastructure: context 기준 (Kafka 에러 전체를 하나로 묶음)
+     * - security_probe: 단일 그룹
+     * - api_error: context 기준
+     * - application: context 기준
+     */
+    private buildGroupKey(entry: LokiLogEntry, category: IssueCategory): string {
+        switch (category) {
+            case 'infrastructure':
+                return `infrastructure:${entry.context}`;
+            case 'security_probe':
+                return 'security_probe';
+            case 'api_error':
+                return `api_error:${entry.context}`;
+            default:
+                return `application:${entry.context}`;
+        }
+    }
+
+    /**
+     * 카테고리와 해결 여부로 심각도를 결정합니다.
+     */
+    private determineSeverity(category: IssueCategory, isResolved: boolean): IssueSeverity {
+        if (category === 'security_probe') return 'info';
+        if (category === 'infrastructure') return isResolved ? 'warning' : 'critical';
+        return 'warning';
+    }
+
+    /**
+     * PM용 한국어 제목을 반환합니다.
+     */
+    private getTitle(groupKey: string, category: IssueCategory): string {
+        const titleMap: Record<string, string> = {
+            'infrastructure:ServerKafka': '채팅 서버 (Kafka) 연결 오류',
+            security_probe: '외부 자동화 스캔 감지',
+        };
+
+        if (titleMap[groupKey]) return titleMap[groupKey];
+        if (category === 'api_error') return 'API 오류 발생';
+        if (category === 'application') return `애플리케이션 오류 (${groupKey.split(':')[1] ?? groupKey})`;
+        return '알 수 없는 오류';
+    }
+
+    /**
+     * PM용 한국어 설명을 반환합니다.
+     */
+    private getDescription(groupKey: string, category: IssueCategory): string {
+        const descMap: Record<string, string> = {
+            'infrastructure:ServerKafka': '채팅 메시지 전송에 영향이 있을 수 있습니다.',
+            security_probe: '알 수 없는 외부 봇이 서버를 스캔했습니다. 서비스에는 영향이 없습니다.',
+        };
+
+        if (descMap[groupKey]) return descMap[groupKey];
+        if (category === 'api_error') return 'API 엔드포인트에서 오류가 발생했습니다. 사용자에게 영향이 있을 수 있습니다.';
+        return '애플리케이션 내부에서 예상치 못한 오류가 발생했습니다.';
+    }
+
+    /**
+     * 이슈 그룹을 기반으로 서비스별 상태를 판단합니다.
+     */
+    private determineServiceHealth(groups: IssueGroup[], now: Date): ServiceHealthInfo {
+        const kafkaGroup = groups.find((g) => g.groupKey === 'infrastructure:ServerKafka');
+        const apiGroup = groups.find((g) => g.category === 'api_error');
+        const redisGroup = groups.find((g) => g.groupKey.includes('Redis') || g.groupKey.includes('redis'));
+
+        return {
+            kafka: this.buildServiceStatus(kafkaGroup, now),
+            redis: this.buildServiceStatus(redisGroup, now),
+            api: this.buildServiceStatus(apiGroup, now),
+        };
+    }
+
+    /**
+     * 단일 이슈 그룹으로 서비스 상태 객체를 빌드합니다.
+     *
+     * - 그룹 없음 → healthy
+     * - 마지막 에러 1시간 이내 → error
+     * - 마지막 에러 1시간 초과 → warning (과거 이슈 있음)
+     */
+    private buildServiceStatus(
+        group: IssueGroup | undefined,
+        now: Date,
+    ): { status: ServiceStatus; lastErrorAt: string | null } {
+        if (!group) {
+            return { status: 'healthy', lastErrorAt: null };
+        }
+
+        const msSinceLast = now.getTime() - new Date(group.lastAt).getTime();
+        const status: ServiceStatus =
+            msSinceLast < LogCategorizerService.ACTIVE_ERROR_THRESHOLD_MS ? 'error' : 'warning';
+
+        return { status, lastErrorAt: group.lastAt };
+    }
+
+    /**
+     * 전체 시스템 상태를 판단합니다.
+     *
+     * - 미해결 critical 그룹 존재 → critical
+     * - 미해결 warning 그룹 존재 → warning
+     * - 모두 해결됐거나 info만 → healthy
+     */
+    private determineOverallStatus(groups: IssueGroup[]): OverallStatus {
+        const hasUnresolvedCritical = groups.some((g) => g.severity === 'critical' && !g.isResolved);
+        if (hasUnresolvedCritical) return 'critical';
+
+        const hasUnresolvedWarning = groups.some((g) => g.severity === 'warning' && !g.isResolved);
+        if (hasUnresolvedWarning) return 'warning';
+
+        return 'healthy';
+    }
+
+    /**
+     * 심각도별 카운트 요약을 빌드합니다.
+     */
+    private buildSummary(groups: IssueGroup[]): { critical: number; warning: number; info: number } {
+        return {
+            critical: groups.filter((g) => g.severity === 'critical' && !g.isResolved).length,
+            warning: groups.filter((g) => g.severity === 'warning' && !g.isResolved).length,
+            info: groups.filter((g) => g.severity === 'info').length,
+        };
+    }
+}

--- a/src/api/platform/admin/dto/request/system-health-filter-request.dto.ts
+++ b/src/api/platform/admin/dto/request/system-health-filter-request.dto.ts
@@ -1,0 +1,26 @@
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 시스템 헬스 조회 필터 요청 DTO
+ */
+export class SystemHealthFilterRequestDto {
+    /**
+     * 조회 기간 (시간 단위)
+     * @example 24
+     */
+    @ApiProperty({
+        description: '조회 기간 (시간 단위). 기본값 24시간, 최대 168시간(7일)',
+        example: 24,
+        minimum: 1,
+        maximum: 168,
+        required: false,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsNumber()
+    @Min(1)
+    @Max(168)
+    periodHours?: number = 24;
+}

--- a/src/api/platform/admin/dto/response/system-health-response.dto.ts
+++ b/src/api/platform/admin/dto/response/system-health-response.dto.ts
@@ -1,0 +1,199 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type {
+    IssueCategory,
+    IssueSeverity,
+    OverallStatus,
+    ServiceStatus,
+} from '../../domain/services/log-categorizer.service';
+
+/**
+ * 단일 서비스 상태 DTO
+ */
+export class ServiceStatusDto {
+    /**
+     * 서비스 상태
+     * @example "healthy"
+     */
+    @ApiProperty({
+        description: '서비스 상태',
+        enum: ['healthy', 'warning', 'error', 'unknown'],
+        example: 'healthy',
+    })
+    status: ServiceStatus;
+
+    /**
+     * 마지막 에러 발생 시각 (없으면 null)
+     * @example "2026-04-12T11:54:07.000Z"
+     */
+    @ApiProperty({
+        description: '마지막 에러 발생 시각 (없으면 null)',
+        example: '2026-04-12T11:54:07.000Z',
+        nullable: true,
+    })
+    lastErrorAt: string | null;
+}
+
+/**
+ * 서비스별 상태 현황 DTO
+ */
+export class ServicesHealthDto {
+    @ApiProperty({ description: '채팅 서버 (Kafka) 상태', type: ServiceStatusDto })
+    kafka: ServiceStatusDto;
+
+    @ApiProperty({ description: 'Redis 캐시 서버 상태', type: ServiceStatusDto })
+    redis: ServiceStatusDto;
+
+    @ApiProperty({ description: 'API 서버 상태', type: ServiceStatusDto })
+    api: ServiceStatusDto;
+}
+
+/**
+ * 심각도별 이슈 건수 요약 DTO
+ */
+export class HealthSummaryDto {
+    /**
+     * 미해결 심각 이슈 수
+     * @example 0
+     */
+    @ApiProperty({ description: '미해결 심각(critical) 이슈 수', example: 0 })
+    critical: number;
+
+    /**
+     * 미해결 경고 이슈 수
+     * @example 1
+     */
+    @ApiProperty({ description: '미해결 경고(warning) 이슈 수', example: 1 })
+    warning: number;
+
+    /**
+     * 정보성 이슈 수 (봇 스캔 등)
+     * @example 2
+     */
+    @ApiProperty({ description: '정보성(info) 이슈 수 (봇 스캔 등)', example: 2 })
+    info: number;
+}
+
+/**
+ * 이슈 그룹 DTO — PM이 읽는 단위
+ */
+export class IssueGroupDto {
+    /**
+     * 이슈 카테고리
+     * @example "infrastructure"
+     */
+    @ApiProperty({
+        description: '이슈 카테고리',
+        enum: ['infrastructure', 'api_error', 'security_probe', 'application'],
+        example: 'infrastructure',
+    })
+    category: IssueCategory;
+
+    /**
+     * 심각도
+     * @example "critical"
+     */
+    @ApiProperty({
+        description: '심각도',
+        enum: ['critical', 'warning', 'info'],
+        example: 'critical',
+    })
+    severity: IssueSeverity;
+
+    /**
+     * PM용 한국어 제목
+     * @example "채팅 서버 (Kafka) 연결 오류"
+     */
+    @ApiProperty({ description: 'PM용 제목 (한국어)', example: '채팅 서버 (Kafka) 연결 오류' })
+    title: string;
+
+    /**
+     * PM용 한국어 설명
+     * @example "채팅 메시지 전송에 영향이 있을 수 있습니다."
+     */
+    @ApiProperty({
+        description: 'PM용 설명 (한국어)',
+        example: '채팅 메시지 전송에 영향이 있을 수 있습니다.',
+    })
+    description: string;
+
+    /**
+     * 발생 횟수
+     * @example 28
+     */
+    @ApiProperty({ description: '발생 횟수', example: 28 })
+    count: number;
+
+    /**
+     * 최초 발생 시각
+     * @example "2026-04-12T10:05:08.000Z"
+     */
+    @ApiProperty({ description: '최초 발생 시각 (ISO 8601)', example: '2026-04-12T10:05:08.000Z' })
+    firstAt: string;
+
+    /**
+     * 최근 발생 시각
+     * @example "2026-04-12T11:54:07.000Z"
+     */
+    @ApiProperty({ description: '최근 발생 시각 (ISO 8601)', example: '2026-04-12T11:54:07.000Z' })
+    lastAt: string;
+
+    /**
+     * 해결 여부 (30분 이상 재발 없으면 true)
+     * @example true
+     */
+    @ApiProperty({ description: '해결 여부 (30분 이상 재발 없으면 true)', example: true })
+    isResolved: boolean;
+}
+
+/**
+ * 시스템 헬스 응답 DTO
+ *
+ * 관리자 대시보드의 "서버 현황" 페이지에서 사용됩니다.
+ */
+export class SystemHealthResponseDto {
+    /**
+     * 전체 시스템 상태
+     * @example "warning"
+     */
+    @ApiProperty({
+        description: '전체 시스템 상태 (healthy | warning | critical)',
+        enum: ['healthy', 'warning', 'critical'],
+        example: 'warning',
+    })
+    overallStatus: OverallStatus;
+
+    /**
+     * 응답 생성 시각
+     * @example "2026-04-14T05:08:50.000Z"
+     */
+    @ApiProperty({ description: '응답 생성 시각 (ISO 8601)', example: '2026-04-14T05:08:50.000Z' })
+    asOf: string;
+
+    /**
+     * 조회 기간
+     */
+    @ApiProperty({
+        description: '조회 기간',
+        example: { from: '2026-04-13T05:08:50.000Z', to: '2026-04-14T05:08:50.000Z' },
+    })
+    period: { from: string; to: string };
+
+    /**
+     * 서비스별 상태
+     */
+    @ApiProperty({ description: '서비스별 상태', type: ServicesHealthDto })
+    services: ServicesHealthDto;
+
+    /**
+     * 심각도별 건수 요약
+     */
+    @ApiProperty({ description: '심각도별 건수 요약', type: HealthSummaryDto })
+    summary: HealthSummaryDto;
+
+    /**
+     * 이슈 그룹 목록 (최신순)
+     */
+    @ApiProperty({ description: '이슈 그룹 목록 (최신순)', type: [IssueGroupDto] })
+    issueGroups: IssueGroupDto[];
+}

--- a/src/api/platform/admin/infrastructure/loki-query.adapter.ts
+++ b/src/api/platform/admin/infrastructure/loki-query.adapter.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { ILokiQueryPort, LokiLogEntry, LokiQueryOptions } from '../application/ports/loki-query.port';
+
+/**
+ * Loki HTTP API 응답 타입 (내부 파싱용)
+ */
+interface LokiStream {
+    stream: {
+        level?: string;
+        context?: string;
+        deployment?: string;
+        [key: string]: string | undefined;
+    };
+    values: [string, string][]; // [nanosecond_timestamp, log_message]
+}
+
+interface LokiQueryRangeResponse {
+    status: string;
+    data: {
+        resultType: string;
+        result: LokiStream[];
+    };
+}
+
+/**
+ * Loki Query Adapter
+ *
+ * Loki의 query_range HTTP API를 호출하여 로그를 가져옵니다.
+ * Promtail이 파싱한 level, context, deployment 라벨을 활용합니다.
+ *
+ * LogQL: {app="pawpong-backend", level=~"error|warn"}
+ */
+@Injectable()
+export class LokiQueryAdapter implements ILokiQueryPort {
+    private readonly lokiUrl: string;
+
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly logger: CustomLoggerService,
+    ) {
+        this.lokiUrl = this.configService.get<string>('LOKI_URL') ?? 'http://loki:3100';
+    }
+
+    /**
+     * error/warn 레벨 로그를 조회합니다.
+     *
+     * Loki에 접근할 수 없는 경우 빈 배열을 반환하여 상위 레이어가 graceful하게 처리할 수 있도록 합니다.
+     */
+    async queryErrorsAndWarnings(options: LokiQueryOptions): Promise<LokiLogEntry[]> {
+        const query = `{app="pawpong-backend", level=~"error|warn"}`;
+
+        try {
+            const response = await axios.get<LokiQueryRangeResponse>(
+                `${this.lokiUrl}/loki/api/v1/query_range`,
+                {
+                    params: {
+                        query,
+                        start: options.from,
+                        end: options.to,
+                        limit: options.limit,
+                        direction: 'backward',
+                    },
+                    timeout: 10_000,
+                },
+            );
+
+            return this.parseStreams(response.data.data?.result ?? []);
+        } catch (error) {
+            this.logger.logError(
+                'queryErrorsAndWarnings',
+                'Loki 쿼리 실패 — 빈 결과 반환',
+                error,
+                LokiQueryAdapter.name,
+            );
+            return [];
+        }
+    }
+
+    /**
+     * Loki /ready 엔드포인트로 가용 여부를 확인합니다.
+     */
+    async isAvailable(): Promise<boolean> {
+        try {
+            await axios.get(`${this.lokiUrl}/ready`, { timeout: 3_000 });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────
+
+    /**
+     * Loki stream 배열을 LokiLogEntry 배열로 파싱합니다.
+     *
+     * Loki 응답 형식:
+     * result = [{ stream: { level, context, deployment, ... }, values: [[nanoTs, message], ...] }]
+     *
+     * nanoTs는 나노초 단위 Unix timestamp 문자열입니다.
+     * 앞 13자리를 잘라 밀리초로 변환합니다.
+     */
+    private parseStreams(streams: LokiStream[]): LokiLogEntry[] {
+        const entries: LokiLogEntry[] = [];
+
+        for (const stream of streams) {
+            const { level = 'unknown', context = '', deployment = '' } = stream.stream;
+
+            for (const [nanoTs, message] of stream.values) {
+                const ms = Number(nanoTs.slice(0, 13));
+                entries.push({
+                    timestamp: new Date(ms).toISOString(),
+                    level,
+                    context,
+                    message,
+                    deployment,
+                });
+            }
+        }
+
+        // 최신순 정렬
+        return entries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    }
+}

--- a/src/api/platform/admin/platform-admin-system-health.controller.ts
+++ b/src/api/platform/admin/platform-admin-system-health.controller.ts
@@ -36,10 +36,12 @@ export class PlatformAdminSystemHealthController {
         @CurrentUser() user: any,
         @Query() filter: SystemHealthFilterRequestDto,
     ): Promise<ApiResponseDto<SystemHealthResponseDto>> {
+        // now를 컨트롤러에서 단일 생성하여 use case에 전달합니다.
+        // 이렇게 해야 응답의 period.from/to와 실제 Loki 쿼리 범위가 동일한 기준으로 계산됩니다.
         const now = new Date();
         const periodHours = filter.periodHours ?? 24;
 
-        const result = await this.getSystemHealthUseCase.execute(user.userId, filter);
+        const result = await this.getSystemHealthUseCase.execute(user.userId, filter, now);
 
         const response: SystemHealthResponseDto = {
             overallStatus: result.overallStatus,

--- a/src/api/platform/admin/platform-admin-system-health.controller.ts
+++ b/src/api/platform/admin/platform-admin-system-health.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+
+import { ApiController } from '../../../common/decorator/swagger.decorator';
+import { JwtAuthGuard } from '../../../common/guard/jwt-auth.guard';
+import { RolesGuard } from '../../../common/guard/roles.guard';
+import { Roles } from '../../../common/decorator/roles.decorator';
+import { CurrentUser } from '../../../common/decorator/user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+
+import { GetSystemHealthUseCase } from './application/use-cases/get-system-health.use-case';
+import { SystemHealthFilterRequestDto } from './dto/request/system-health-filter-request.dto';
+import { SystemHealthResponseDto } from './dto/response/system-health-response.dto';
+import { ApiGetSystemHealthEndpoint } from './swagger/decorators';
+
+/**
+ * 플랫폼 Admin — 시스템 헬스 컨트롤러
+ *
+ * 관리자 대시보드의 "서버 현황" 페이지에 데이터를 제공합니다.
+ * Loki 로그를 분석하여 PM이 읽기 쉬운 형태로 반환합니다.
+ */
+@ApiController('플랫폼 관리자 — 서버 현황')
+@Controller('platform-admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+export class PlatformAdminSystemHealthController {
+    constructor(private readonly getSystemHealthUseCase: GetSystemHealthUseCase) {}
+
+    /**
+     * GET /api/platform-admin/system-health
+     *
+     * 서버 현황을 조회합니다.
+     */
+    @Get('system-health')
+    @ApiGetSystemHealthEndpoint()
+    async getSystemHealth(
+        @CurrentUser() user: any,
+        @Query() filter: SystemHealthFilterRequestDto,
+    ): Promise<ApiResponseDto<SystemHealthResponseDto>> {
+        const now = new Date();
+        const periodHours = filter.periodHours ?? 24;
+
+        const result = await this.getSystemHealthUseCase.execute(user.userId, filter);
+
+        const response: SystemHealthResponseDto = {
+            overallStatus: result.overallStatus,
+            asOf: now.toISOString(),
+            period: {
+                from: new Date(now.getTime() - periodHours * 60 * 60 * 1000).toISOString(),
+                to: now.toISOString(),
+            },
+            services: result.services,
+            summary: result.summary,
+            issueGroups: result.issueGroups,
+        };
+
+        return ApiResponseDto.success(response, '서버 현황이 조회되었습니다.');
+    }
+}

--- a/src/api/platform/admin/platform-admin-system-health.controller.ts
+++ b/src/api/platform/admin/platform-admin-system-health.controller.ts
@@ -52,7 +52,8 @@ export class PlatformAdminSystemHealthController {
             },
             services: result.services,
             summary: result.summary,
-            issueGroups: result.issueGroups,
+            // groupKey는 도메인 내부 식별자이므로 API 응답에서 제외합니다.
+            issueGroups: result.issueGroups.map(({ groupKey: _, ...rest }) => rest),
         };
 
         return ApiResponseDto.success(response, '서버 현황이 조회되었습니다.');

--- a/src/api/platform/admin/platform-admin.module.ts
+++ b/src/api/platform/admin/platform-admin.module.ts
@@ -2,8 +2,13 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { PlatformAdminController } from './platform-admin.controller';
+import { PlatformAdminSystemHealthController } from './platform-admin-system-health.controller';
 
 import { PlatformAdminService } from './platform-admin.service';
+import { GetSystemHealthUseCase } from './application/use-cases/get-system-health.use-case';
+import { LogCategorizerService } from './domain/services/log-categorizer.service';
+import { LokiQueryAdapter } from './infrastructure/loki-query.adapter';
+import { LOKI_QUERY_PORT } from './application/ports/loki-query.port';
 
 import { Admin, AdminSchema } from '../../../schema/admin.schema';
 import { Breeder, BreederSchema } from '../../../schema/breeder.schema';
@@ -14,9 +19,10 @@ import { AdoptionApplication, AdoptionApplicationSchema } from '../../../schema/
 /**
  * 플랫폼 Admin 모듈
  *
- * 플랫폼 전체 통계 관련 관리자 기능을 제공합니다:
+ * 플랫폼 전체 통계 및 시스템 헬스 관련 관리자 기능을 제공합니다:
  * - 플랫폼 통계 조회
  * - MVP 통계 조회
+ * - 시스템 헬스 조회 (Loki 로그 분석)
  */
 @Module({
     imports: [
@@ -28,8 +34,16 @@ import { AdoptionApplication, AdoptionApplicationSchema } from '../../../schema/
             { name: AdoptionApplication.name, schema: AdoptionApplicationSchema },
         ]),
     ],
-    controllers: [PlatformAdminController],
-    providers: [PlatformAdminService],
+    controllers: [PlatformAdminController, PlatformAdminSystemHealthController],
+    providers: [
+        PlatformAdminService,
+        GetSystemHealthUseCase,
+        LogCategorizerService,
+        {
+            provide: LOKI_QUERY_PORT,
+            useClass: LokiQueryAdapter,
+        },
+    ],
     exports: [PlatformAdminService],
 })
 export class PlatformAdminModule {}

--- a/src/api/platform/admin/swagger/decorators.ts
+++ b/src/api/platform/admin/swagger/decorators.ts
@@ -14,7 +14,7 @@ export function ApiGetSystemHealthEndpoint() {
 서버에서 발생한 로그를 분석하여 PM이 읽기 쉬운 형태의 시스템 상태를 반환합니다.
 
 **분류 카테고리:**
-- \`infrastructure\` — Kafka 등 인프라 연결 오류
+- \`infrastructure\` — Kafka, Redis 등 인프라 연결 오류
 - \`api_error\` — API 엔드포인트 오류
 - \`security_probe\` — 외부 봇/스캐너 스캔 (서비스 영향 없음)
 - \`application\` — 애플리케이션 내부 오류

--- a/src/api/platform/admin/swagger/decorators.ts
+++ b/src/api/platform/admin/swagger/decorators.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+
+import { SystemHealthResponseDto } from '../dto/response/system-health-response.dto';
+
+/**
+ * GET /platform-admin/system-health Swagger 명세
+ */
+export function ApiGetSystemHealthEndpoint() {
+    return applyDecorators(
+        ApiOperation({
+            summary: '시스템 헬스 조회',
+            description: `
+서버에서 발생한 로그를 분석하여 PM이 읽기 쉬운 형태의 시스템 상태를 반환합니다.
+
+**분류 카테고리:**
+- \`infrastructure\` — Kafka 등 인프라 연결 오류
+- \`api_error\` — API 엔드포인트 오류
+- \`security_probe\` — 외부 봇/스캐너 스캔 (서비스 영향 없음)
+- \`application\` — 애플리케이션 내부 오류
+
+**해결 판단 기준:** 마지막 발생 후 30분 이상 재발 없으면 \`isResolved: true\`
+
+**서비스 상태 판단 기준:**
+- 마지막 에러 1시간 이내 → \`error\`
+- 마지막 에러 1시간 초과 → \`warning\`
+- 에러 없음 → \`healthy\`
+            `.trim(),
+        }),
+        ApiQuery({
+            name: 'periodHours',
+            required: false,
+            description: '조회 기간 (시간 단위). 기본 24시간, 최대 168시간(7일)',
+            example: 24,
+            type: Number,
+        }),
+        ApiResponse({
+            status: 200,
+            description: '시스템 헬스 조회 성공',
+            type: SystemHealthResponseDto,
+        }),
+        ApiResponse({ status: 403, description: '통계 조회 권한 없음' }),
+    );
+}

--- a/src/api/platform/admin/test/platform-admin-system-health.e2e-spec.ts
+++ b/src/api/platform/admin/test/platform-admin-system-health.e2e-spec.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 import { createTestingApp, cleanupDatabase, seedAdmin } from '../../../../common/test/test-utils';
 import { LOKI_QUERY_PORT } from '../application/ports/loki-query.port';
 import { LogCategorizerService } from '../domain/services/log-categorizer.service';
+import type { SystemHealthResponseDto } from '../dto/response/system-health-response.dto';
 
 /**
  * Platform Admin — 시스템 헬스 E2E 테스트
@@ -195,6 +196,61 @@ describe('Platform Admin — System Health E2E', () => {
             expect(data.services.kafka.status).toBe('error');
             expect(data.overallStatus).toBe('critical');
         });
+
+        it('Redis(IoRedis) 에러가 최근 1시간 이내면 redis status가 error여야 한다', async () => {
+            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([
+                {
+                    timestamp: fiveMinutesAgo,
+                    level: 'error',
+                    context: 'IoRedis',
+                    message: 'connect ECONNREFUSED redis:6379',
+                    deployment: 'green',
+                },
+            ]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body as unknown as { data: SystemHealthResponseDto };
+            expect(data.services.redis.status).toBe('error');
+            expect(data.overallStatus).toBe('critical');
+        });
+
+        it('Kafka와 Redis 에러가 동시에 있으면 각각 독립적으로 추적되어야 한다', async () => {
+            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([
+                {
+                    timestamp: fiveMinutesAgo,
+                    level: 'error',
+                    context: 'ServerKafka',
+                    message: 'ERROR [Connection] connect ECONNREFUSED kafka:29092',
+                    deployment: 'green',
+                },
+                {
+                    timestamp: fiveMinutesAgo,
+                    level: 'error',
+                    context: 'IoRedis',
+                    message: 'connect ECONNREFUSED redis:6379',
+                    deployment: 'green',
+                },
+            ]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body as unknown as { data: SystemHealthResponseDto };
+            expect(data.issueGroups).toHaveLength(2);
+            expect(data.services.kafka.status).toBe('error');
+            expect(data.services.redis.status).toBe('error');
+            expect(data.overallStatus).toBe('critical');
+        });
     });
 
     // ─────────────────────────────────────────────
@@ -225,6 +281,18 @@ describe('Platform Admin — System Health E2E', () => {
                 .get('/api/platform-admin/system-health?periodHours=169')
                 .set('Authorization', `Bearer ${adminToken}`)
                 .expect(400);
+        });
+
+        it('periodHours=168 요청 시 Loki 쿼리 limit이 1000보다 커야 한다', async () => {
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([]);
+
+            await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health?periodHours=168')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const calls = mockLokiQueryPort.queryErrorsAndWarnings.mock.calls as Array<Array<{ limit: number }>>;
+            expect(calls[0][0].limit).toBeGreaterThan(1000);
         });
     });
 });
@@ -308,6 +376,50 @@ describe('LogCategorizerService — 단위 테스트', () => {
     it('미해결 infrastructure 에러가 있으면 overallStatus가 critical이어야 한다', () => {
         const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
         const result = service.categorize([makeEntry({ timestamp: recent })]);
+        expect(result.overallStatus).toBe('critical');
+    });
+
+    // ── Redis 분류 ──────────────────────────────────
+
+    it('IoRedis 에러는 infrastructure로 분류되어야 한다', () => {
+        const result = service.categorize([
+            makeEntry({ context: 'IoRedis', message: 'connect ECONNREFUSED redis:6379' }),
+        ]);
+        expect(result.issueGroups[0].category).toBe('infrastructure');
+    });
+
+    it('Redis 에러의 groupKey는 infrastructure:Redis여야 한다', () => {
+        const result = service.categorize([
+            makeEntry({ context: 'IoRedis', message: 'connect ECONNREFUSED redis:6379' }),
+        ]);
+        expect(result.issueGroups[0].groupKey).toBe('infrastructure:Redis');
+    });
+
+    it('최근 1시간 이내 Redis 에러가 있으면 services.redis.status가 error여야 한다', () => {
+        const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+        const result = service.categorize([
+            makeEntry({ context: 'IoRedis', message: 'connect ECONNREFUSED redis:6379', timestamp: recent }),
+        ]);
+        expect(result.services.redis.status).toBe('error');
+    });
+
+    it('1시간 이상 경과한 Redis 에러는 services.redis.status가 warning이어야 한다', () => {
+        const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+        const result = service.categorize([
+            makeEntry({ context: 'IoRedis', message: 'connect ECONNREFUSED redis:6379', timestamp: twoHoursAgo }),
+        ]);
+        expect(result.services.redis.status).toBe('warning');
+    });
+
+    it('Kafka와 Redis 에러가 동시에 있으면 2개의 독립 그룹이어야 한다', () => {
+        const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+        const result = service.categorize([
+            makeEntry({ context: 'ServerKafka', message: 'ECONNREFUSED kafka:29092', timestamp: recent }),
+            makeEntry({ context: 'IoRedis', message: 'ECONNREFUSED redis:6379', timestamp: recent }),
+        ]);
+        expect(result.issueGroups).toHaveLength(2);
+        expect(result.services.kafka.status).toBe('error');
+        expect(result.services.redis.status).toBe('error');
         expect(result.overallStatus).toBe('critical');
     });
 });

--- a/src/api/platform/admin/test/platform-admin-system-health.e2e-spec.ts
+++ b/src/api/platform/admin/test/platform-admin-system-health.e2e-spec.ts
@@ -1,0 +1,313 @@
+import { INestApplication } from '@nestjs/common';
+import { getConnectionToken } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
+import request from 'supertest';
+
+import { createTestingApp, cleanupDatabase, seedAdmin } from '../../../../common/test/test-utils';
+import { LOKI_QUERY_PORT } from '../application/ports/loki-query.port';
+import { LogCategorizerService } from '../domain/services/log-categorizer.service';
+
+/**
+ * Platform Admin — 시스템 헬스 E2E 테스트
+ *
+ * LokiQueryAdapter는 실제 Loki 서버가 없으므로 Mock으로 대체합니다.
+ * 분류 로직은 LogCategorizerService 유닛 테스트에서 별도 검증합니다.
+ *
+ * 테스트 대상 API:
+ * GET /api/platform-admin/system-health
+ */
+describe('Platform Admin — System Health E2E', () => {
+    let app: INestApplication;
+    let dbConnection: Connection;
+    let adminToken: string;
+
+    /** Loki Port Mock — 실제 Loki 없이 고정 데이터 반환 */
+    const mockLokiQueryPort = {
+        queryErrorsAndWarnings: jest.fn(),
+        isAvailable: jest.fn().mockResolvedValue(true),
+    };
+
+    beforeAll(async () => {
+        app = await createTestingApp([
+            {
+                provide: LOKI_QUERY_PORT,
+                useValue: mockLokiQueryPort,
+            },
+        ]);
+
+        dbConnection = app.get<Connection>(getConnectionToken());
+
+        const adminPassword = 'admin1234';
+        const { email } = await seedAdmin(app, adminPassword);
+
+        const loginResponse = await request(app.getHttpServer())
+            .post('/api/auth-admin/login')
+            .send({ email, password: adminPassword })
+            .expect(200);
+
+        adminToken = loginResponse.body.data.accessToken;
+    });
+
+    afterAll(async () => {
+        await cleanupDatabase(app);
+        await app.close();
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // ─────────────────────────────────────────────
+    // 1. 인증/권한 검증
+    // ─────────────────────────────────────────────
+
+    describe('인증 및 권한', () => {
+        it('토큰 없이 요청 시 401을 반환해야 한다', async () => {
+            await request(app.getHttpServer()).get('/api/platform-admin/system-health').expect(401);
+        });
+
+        it('관리자 토큰으로 요청 시 200을 반환해야 한다', async () => {
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([]);
+
+            await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+        });
+    });
+
+    // ─────────────────────────────────────────────
+    // 2. 응답 구조 검증
+    // ─────────────────────────────────────────────
+
+    describe('응답 구조', () => {
+        it('로그가 없을 때 healthy 상태를 반환해야 한다', async () => {
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body;
+            expect(data.overallStatus).toBe('healthy');
+            expect(data.issueGroups).toHaveLength(0);
+            expect(data.summary).toEqual({ critical: 0, warning: 0, info: 0 });
+            expect(data.services.kafka.status).toBe('healthy');
+            expect(data.services.redis.status).toBe('healthy');
+            expect(data.services.api.status).toBe('healthy');
+        });
+
+        it('응답에 필수 필드가 모두 포함되어야 한다', async () => {
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body;
+            expect(data).toHaveProperty('overallStatus');
+            expect(data).toHaveProperty('asOf');
+            expect(data).toHaveProperty('period');
+            expect(data).toHaveProperty('services');
+            expect(data).toHaveProperty('summary');
+            expect(data).toHaveProperty('issueGroups');
+            expect(data.period).toHaveProperty('from');
+            expect(data.period).toHaveProperty('to');
+        });
+    });
+
+    // ─────────────────────────────────────────────
+    // 3. 이슈 분류 검증
+    // ─────────────────────────────────────────────
+
+    describe('이슈 분류', () => {
+        it('Kafka 에러가 있을 때 infrastructure 그룹이 생성되어야 한다', async () => {
+            const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([
+                {
+                    timestamp: twoHoursAgo,
+                    level: 'error',
+                    context: 'ServerKafka',
+                    message: 'ERROR [Connection] connect ECONNREFUSED kafka:29092',
+                    deployment: 'green',
+                },
+            ]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body;
+            const kafkaGroup = data.issueGroups.find((g: any) => g.category === 'infrastructure');
+            expect(kafkaGroup).toBeDefined();
+            expect(kafkaGroup.title).toBe('채팅 서버 (Kafka) 연결 오류');
+            expect(kafkaGroup.isResolved).toBe(true); // 2시간 전 = 해결됨
+            expect(data.services.kafka.status).toBe('warning'); // 1시간 초과 = warning
+        });
+
+        it('비-API 경로 404는 security_probe로 분류되어야 한다', async () => {
+            const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([
+                {
+                    timestamp: tenMinutesAgo,
+                    level: 'error',
+                    context: 'HttpExceptionFilter',
+                    message: '[GET] /autodiscover/autodiscover.json?@zdi/Powershell - 404',
+                    deployment: 'green',
+                },
+            ]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body;
+            const probeGroup = data.issueGroups.find((g: any) => g.category === 'security_probe');
+            expect(probeGroup).toBeDefined();
+            expect(probeGroup.severity).toBe('info');
+        });
+
+        it('Kafka 에러가 최근 1시간 이내면 kafka status가 error여야 한다', async () => {
+            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([
+                {
+                    timestamp: fiveMinutesAgo,
+                    level: 'error',
+                    context: 'ServerKafka',
+                    message: 'ERROR [Connection] connect ECONNREFUSED kafka:29092',
+                    deployment: 'green',
+                },
+            ]);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+
+            const { data } = res.body;
+            expect(data.services.kafka.status).toBe('error');
+            expect(data.overallStatus).toBe('critical');
+        });
+    });
+
+    // ─────────────────────────────────────────────
+    // 4. 쿼리 파라미터 검증
+    // ─────────────────────────────────────────────
+
+    describe('쿼리 파라미터', () => {
+        it('periodHours=48로 요청하면 period.from이 48시간 전이어야 한다', async () => {
+            mockLokiQueryPort.queryErrorsAndWarnings.mockResolvedValue([]);
+
+            const before = Date.now();
+            const res = await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health?periodHours=48')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(200);
+            const after = Date.now();
+
+            const from = new Date(res.body.data.period.from).getTime();
+            const expected48hAgo = before - 48 * 60 * 60 * 1000;
+
+            // 요청 전후 시간 사이에 있어야 함 (오차 허용 1초)
+            expect(from).toBeGreaterThanOrEqual(expected48hAgo - 1000);
+            expect(from).toBeLessThanOrEqual(after - 47 * 60 * 60 * 1000);
+        });
+
+        it('periodHours가 169 이상이면 400을 반환해야 한다', async () => {
+            await request(app.getHttpServer())
+                .get('/api/platform-admin/system-health?periodHours=169')
+                .set('Authorization', `Bearer ${adminToken}`)
+                .expect(400);
+        });
+    });
+});
+
+// ─────────────────────────────────────────────
+// LogCategorizerService 유닛 테스트
+// (순수 도메인 로직 — 외부 의존성 없음)
+// ─────────────────────────────────────────────
+
+describe('LogCategorizerService — 단위 테스트', () => {
+    let service: LogCategorizerService;
+
+    beforeEach(() => {
+        service = new LogCategorizerService();
+    });
+
+    const makeEntry = (overrides: Partial<Parameters<typeof service.categorize>[0][0]> = {}) => ({
+        timestamp: new Date().toISOString(),
+        level: 'error',
+        context: 'ServerKafka',
+        message: 'connect ECONNREFUSED kafka:29092',
+        deployment: 'green',
+        ...overrides,
+    });
+
+    it('로그가 없으면 overallStatus가 healthy여야 한다', () => {
+        const result = service.categorize([]);
+        expect(result.overallStatus).toBe('healthy');
+        expect(result.issueGroups).toHaveLength(0);
+    });
+
+    it('ServerKafka 에러는 infrastructure로 분류되어야 한다', () => {
+        const result = service.categorize([makeEntry()]);
+        expect(result.issueGroups[0].category).toBe('infrastructure');
+    });
+
+    it('/api/ 없는 경로의 HttpExceptionFilter 에러는 security_probe여야 한다', () => {
+        const result = service.categorize([
+            makeEntry({
+                context: 'HttpExceptionFilter',
+                message: '[GET] /autodiscover/autodiscover.json - 404',
+            }),
+        ]);
+        expect(result.issueGroups[0].category).toBe('security_probe');
+        expect(result.issueGroups[0].severity).toBe('info');
+    });
+
+    it('/api/ 경로의 HttpExceptionFilter 에러는 api_error여야 한다', () => {
+        const result = service.categorize([
+            makeEntry({
+                context: 'HttpExceptionFilter',
+                message: '[GET] /api/breeder/123 - 500',
+            }),
+        ]);
+        expect(result.issueGroups[0].category).toBe('api_error');
+    });
+
+    it('30분 이상 지난 에러는 isResolved가 true여야 한다', () => {
+        const fortyMinutesAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
+        const result = service.categorize([makeEntry({ timestamp: fortyMinutesAgo })]);
+        expect(result.issueGroups[0].isResolved).toBe(true);
+    });
+
+    it('30분 이내 에러는 isResolved가 false여야 한다', () => {
+        const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+        const result = service.categorize([makeEntry({ timestamp: tenMinutesAgo })]);
+        expect(result.issueGroups[0].isResolved).toBe(false);
+    });
+
+    it('같은 카테고리의 여러 에러는 하나의 그룹으로 묶여야 한다', () => {
+        const entries = [
+            makeEntry({ timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString() }),
+            makeEntry({ timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString() }),
+            makeEntry({ timestamp: new Date(Date.now() - 2 * 60 * 1000).toISOString() }),
+        ];
+        const result = service.categorize(entries);
+        expect(result.issueGroups).toHaveLength(1);
+        expect(result.issueGroups[0].count).toBe(3);
+    });
+
+    it('미해결 infrastructure 에러가 있으면 overallStatus가 critical이어야 한다', () => {
+        const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+        const result = service.categorize([makeEntry({ timestamp: recent })]);
+        expect(result.overallStatus).toBe('critical');
+    });
+});

--- a/src/common/test/test-utils.ts
+++ b/src/common/test/test-utils.ts
@@ -1,4 +1,4 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { getConnectionToken } from '@nestjs/mongoose';
 import { Connection } from 'mongoose';
@@ -10,6 +10,12 @@ import { AppModule } from '../../app.module';
 /** 테스트용 인메모리 MongoDB 인스턴스 */
 let mongod: MongoMemoryServer;
 
+/** createTestingApp에 넘길 Provider 오버라이드 항목 */
+export interface ProviderOverride {
+    provide: any;
+    useValue: any;
+}
+
 /**
  * E2E 테스트용 NestJS 애플리케이션 생성
  *
@@ -18,8 +24,10 @@ let mongod: MongoMemoryServer;
  * MongoDBMemoryServer를 사용하여 외부 DB 의존 없이 독립 실행 가능합니다.
  * - 글로벌 프리픽스: /api
  * - 글로벌 파이프: ValidationPipe (transform, whitelist 활성화)
+ *
+ * @param overrides 특정 Provider를 Mock으로 교체할 때 사용 (기본값: 빈 배열)
  */
-export async function createTestingApp(): Promise<INestApplication> {
+export async function createTestingApp(overrides: ProviderOverride[] = []): Promise<INestApplication> {
     // 인메모리 MongoDB 서버 시작
     mongod = await MongoMemoryServer.create();
     const mongoUri = mongod.getUri();
@@ -27,9 +35,15 @@ export async function createTestingApp(): Promise<INestApplication> {
     // MONGODB_URI 환경변수를 인메모리 서버로 오버라이드
     process.env.MONGODB_URI = mongoUri;
 
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    let builder = Test.createTestingModule({
         imports: [AppModule],
-    }).compile();
+    });
+
+    for (const override of overrides) {
+        builder = builder.overrideProvider(override.provide).useValue(override.useValue);
+    }
+
+    const moduleFixture = await builder.compile();
 
     const app = moduleFixture.createNestApplication();
 


### PR DESCRIPTION
## Summary

- Loki 로그를 분석해 PM이 읽기 쉬운 형태로 시스템 상태를 반환하는 API 구현
- 헥사고날 아키텍처(Port/Adapter) 기반으로 설계, Loki 장애 시 graceful degradation 적용
- TDD 방식으로 진행 — 버그 발견 후 실패하는 테스트 먼저 작성, 구현으로 통과시킴 (25/25)

## 주요 구현 내용

- `GET /api/platform-admin/system-health` 엔드포인트 추가 (관리자 전용)
- Loki query_range API 호출 → 로그를 4가지 카테고리로 자동 분류
  - `infrastructure` — Kafka, Redis 연결 오류
  - `api_error` — API 5xx 오류
  - `security_probe` — 외부 봇/스캐너 스캔
  - `application` — 애플리케이션 내부 오류
- `overallStatus` / 서비스별 상태(`kafka`, `redis`, `api`) / 이슈 그룹 목록 반환
- 조회 기간 `periodHours` 파라미터 지원 (기본 24h, 최대 168h)

## 버그 수정 (TDD)

- Redis 감지 로직 취약 수정 — 문자열 매칭 → `REDIS_CONTEXTS` Set + 정규화된 groupKey(`infrastructure:Redis`)
- Loki 쿼리 limit 1000 하드코딩 → `periodHours` 기반 동적 산정 (최대 5000)
- `now` 이중 생성 제거 — 컨트롤러에서 단일 생성 후 use case에 주입, `period.from/to`와 쿼리 범위 일치

## API 정리

- `groupKey` 응답에서 제거 (도메인 내부 식별자, `IssueGroupDto` 스펙과 불일치 해소)
- Swagger `infrastructure` 카테고리 설명에 Redis 명시

## Test plan

- `yarn test:e2e --testPathPatterns="platform-admin-system-health" --verbose`
- 25개 테스트 전부 통과 확인
  - 인증/권한, 응답 구조, 이슈 분류 (Kafka, Redis, security_probe), 쿼리 파라미터 검증
  - Redis 분류 유닛 테스트 5개 포함 (IoRedis → infrastructure, groupKey, status error/warning)
- Postman으로 로컬 실서버 응답 확인 완료
