### PR TITLE
feat(discord): critical 에러 웹훅 알림 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { RedisModule } from './common/redis/redis.module';
 import { KafkaModule } from './common/kafka/kafka.module';
 import { AlimtalkModule } from './common/alimtalk/alimtalk.module';
 import { AlimtalkAdminModule } from './common/alimtalk/admin/alimtalk-admin.module';
+import { DiscordWebhookModule } from './common/discord/discord-webhook.module';
 
 import { AuthModule } from './api/auth/auth.module';
 import { HomeModule } from './api/home/home.module';
@@ -42,6 +43,7 @@ import { ChatModule } from './api/chat/chat.module';
         }),
         WinstonModule.forRoot(winstonConfig),
         LoggerModule,
+        DiscordWebhookModule,
         RedisModule,
         KafkaModule,
         DatabaseModule,

--- a/src/common/discord/application/ports/discord-error-alert.port.ts
+++ b/src/common/discord/application/ports/discord-error-alert.port.ts
@@ -1,0 +1,32 @@
+/**
+ * Discord 에러 알림 심각도
+ */
+export type DiscordErrorAlertSeverity = 'error' | 'critical';
+
+/**
+ * Discord 에러 알림 요청
+ */
+export interface DiscordErrorAlertRequest {
+    severity: DiscordErrorAlertSeverity;
+    context: string;
+    message: string;
+    statusCode?: number;
+    method?: string;
+    path?: string;
+    stack?: string;
+    userId?: string;
+    timestamp?: Date;
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Discord 에러 알림 발송 Port
+ *
+ * 외부 시스템(Discord Webhook) 의존성을 애플리케이션 계층 밖으로 분리합니다.
+ */
+export interface DiscordErrorAlertPort {
+    sendCriticalErrorAlert(request: DiscordErrorAlertRequest): Promise<void>;
+}
+
+/** Discord 에러 알림 Port 주입 토큰 */
+export const DISCORD_ERROR_ALERT_PORT = Symbol('DISCORD_ERROR_ALERT_PORT');

--- a/src/common/discord/application/use-cases/notify-critical-error.use-case.spec.ts
+++ b/src/common/discord/application/use-cases/notify-critical-error.use-case.spec.ts
@@ -1,0 +1,79 @@
+import { NotifyCriticalErrorUseCase } from './notify-critical-error.use-case';
+import { DiscordErrorAlertPolicyService } from '../../domain/services/discord-error-alert-policy.service';
+import { DiscordErrorAlertPort } from '../ports/discord-error-alert.port';
+import { CustomLoggerService } from '../../../logger/custom-logger.service';
+
+describe('NotifyCriticalErrorUseCase', () => {
+    let useCase: NotifyCriticalErrorUseCase;
+    let errorAlertPort: jest.Mocked<DiscordErrorAlertPort>;
+    let logger: jest.Mocked<Pick<CustomLoggerService, 'logError'>>;
+
+    beforeEach(() => {
+        errorAlertPort = {
+            sendCriticalErrorAlert: jest.fn().mockResolvedValue(undefined),
+        };
+        logger = {
+            logError: jest.fn(),
+        };
+
+        useCase = new NotifyCriticalErrorUseCase(
+            new DiscordErrorAlertPolicyService(),
+            errorAlertPort,
+            logger as unknown as CustomLoggerService,
+        );
+    });
+
+    it('critical 5xx 에러를 Discord 알림 Port로 전달해야 한다', async () => {
+        const result = await useCase.execute(
+            {
+                severity: 'critical',
+                context: 'AllExceptionsFilter',
+                message: 'Internal server error',
+                statusCode: 500,
+                method: 'GET',
+                path: '/api/test',
+            },
+            new Date('2026-04-16T00:00:00.000Z'),
+        );
+
+        expect(result).toEqual({ sent: true });
+        expect(errorAlertPort.sendCriticalErrorAlert).toHaveBeenCalledTimes(1);
+        expect(errorAlertPort.sendCriticalErrorAlert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                context: 'AllExceptionsFilter',
+                statusCode: 500,
+                timestamp: new Date('2026-04-16T00:00:00.000Z'),
+            }),
+        );
+    });
+
+    it('4xx 에러는 Discord 알림을 보내지 않아야 한다', async () => {
+        const result = await useCase.execute({
+            severity: 'error',
+            context: 'HttpExceptionFilter',
+            message: 'Bad Request',
+            statusCode: 400,
+        });
+
+        expect(result).toEqual({ sent: false, reason: 'filtered' });
+        expect(errorAlertPort.sendCriticalErrorAlert).not.toHaveBeenCalled();
+    });
+
+    it('같은 에러가 쿨다운 안에 반복되면 한 번만 보내야 한다', async () => {
+        const request = {
+            severity: 'critical' as const,
+            context: 'AllExceptionsFilter',
+            message: 'Redis connection failed',
+            statusCode: 500,
+            method: 'GET',
+            path: '/api/test',
+        };
+
+        const first = await useCase.execute(request, new Date('2026-04-16T00:00:00.000Z'));
+        const second = await useCase.execute(request, new Date('2026-04-16T00:01:00.000Z'));
+
+        expect(first).toEqual({ sent: true });
+        expect(second).toEqual({ sent: false, reason: 'cooldown' });
+        expect(errorAlertPort.sendCriticalErrorAlert).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/common/discord/application/use-cases/notify-critical-error.use-case.ts
+++ b/src/common/discord/application/use-cases/notify-critical-error.use-case.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../logger/custom-logger.service';
+import { DISCORD_ERROR_ALERT_PORT } from '../ports/discord-error-alert.port';
+import type { DiscordErrorAlertPort, DiscordErrorAlertRequest } from '../ports/discord-error-alert.port';
+import { DiscordErrorAlertPolicyService } from '../../domain/services/discord-error-alert-policy.service';
+
+export type NotifyCriticalErrorResult = {
+    sent: boolean;
+    reason?: 'filtered' | 'cooldown' | 'failed';
+};
+
+/**
+ * Critical 에러 Discord 알림 Use Case
+ *
+ * 필터링, 중복 방지, 외부 알림 발송 오케스트레이션만 담당합니다.
+ */
+@Injectable()
+export class NotifyCriticalErrorUseCase {
+    private readonly recentAlertMap = new Map<string, number>();
+
+    constructor(
+        private readonly policyService: DiscordErrorAlertPolicyService,
+        @Inject(DISCORD_ERROR_ALERT_PORT)
+        private readonly errorAlertPort: DiscordErrorAlertPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    /**
+     * 운영자가 즉시 알아야 하는 에러를 Discord로 알립니다.
+     */
+    async execute(request: DiscordErrorAlertRequest, now: Date = new Date()): Promise<NotifyCriticalErrorResult> {
+        if (!this.policyService.shouldNotify(request)) {
+            return { sent: false, reason: 'filtered' };
+        }
+
+        const deduplicationKey = this.policyService.buildDeduplicationKey(request);
+        const lastSentAt = this.recentAlertMap.get(deduplicationKey);
+        const nowTime = now.getTime();
+
+        if (lastSentAt && nowTime - lastSentAt < this.policyService.getCooldownMs()) {
+            return { sent: false, reason: 'cooldown' };
+        }
+
+        try {
+            await this.errorAlertPort.sendCriticalErrorAlert({
+                ...request,
+                timestamp: request.timestamp ?? now,
+            });
+            this.recentAlertMap.set(deduplicationKey, nowTime);
+            this.cleanupExpiredAlerts(nowTime);
+            return { sent: true };
+        } catch (error) {
+            this.logger.logError('NotifyCriticalErrorUseCase', 'Discord critical 에러 알림 실패', error);
+            return { sent: false, reason: 'failed' };
+        }
+    }
+
+    /**
+     * 오래된 중복 방지 키를 정리하여 메모리 증가를 제한합니다.
+     */
+    private cleanupExpiredAlerts(nowTime: number): void {
+        const cooldownMs = this.policyService.getCooldownMs();
+
+        for (const [key, sentAt] of this.recentAlertMap.entries()) {
+            if (nowTime - sentAt >= cooldownMs) {
+                this.recentAlertMap.delete(key);
+            }
+        }
+    }
+}

--- a/src/common/discord/discord-webhook.module.ts
+++ b/src/common/discord/discord-webhook.module.ts
@@ -1,17 +1,31 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
 import { CustomLoggerService } from '../logger/custom-logger.service';
+import { DISCORD_ERROR_ALERT_PORT } from './application/ports/discord-error-alert.port';
+import { NotifyCriticalErrorUseCase } from './application/use-cases/notify-critical-error.use-case';
 import { DiscordWebhookService } from './discord-webhook.service';
+import { DiscordErrorAlertPolicyService } from './domain/services/discord-error-alert-policy.service';
+import { DiscordErrorAlertAdapter } from './infrastructure/discord-error-alert.adapter';
 
 /**
  * 디스코드 웹훅 모듈
  *
  * 디스코드로 실시간 알림을 전송하는 기능을 제공합니다.
  */
+@Global()
 @Module({
     imports: [ConfigModule],
-    providers: [DiscordWebhookService, CustomLoggerService],
-    exports: [DiscordWebhookService],
+    providers: [
+        DiscordWebhookService,
+        DiscordErrorAlertPolicyService,
+        NotifyCriticalErrorUseCase,
+        {
+            provide: DISCORD_ERROR_ALERT_PORT,
+            useClass: DiscordErrorAlertAdapter,
+        },
+        CustomLoggerService,
+    ],
+    exports: [DiscordWebhookService, NotifyCriticalErrorUseCase],
 })
 export class DiscordWebhookModule {}

--- a/src/common/discord/domain/services/discord-error-alert-policy.service.spec.ts
+++ b/src/common/discord/domain/services/discord-error-alert-policy.service.spec.ts
@@ -1,0 +1,46 @@
+import { DiscordErrorAlertPolicyService } from './discord-error-alert-policy.service';
+
+describe('DiscordErrorAlertPolicyService', () => {
+    let service: DiscordErrorAlertPolicyService;
+
+    beforeEach(() => {
+        service = new DiscordErrorAlertPolicyService();
+    });
+
+    it('5xx 에러는 알림 대상으로 판단해야 한다', () => {
+        const result = service.shouldNotify({
+            severity: 'critical',
+            context: 'AllExceptionsFilter',
+            message: 'Internal server error',
+            statusCode: 500,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('4xx 에러는 알림 대상에서 제외해야 한다', () => {
+        const result = service.shouldNotify({
+            severity: 'error',
+            context: 'HttpExceptionFilter',
+            message: 'Unauthorized',
+            statusCode: 401,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('같은 원인의 에러는 동일한 중복 방지 키를 생성해야 한다', () => {
+        const baseRequest = {
+            severity: 'critical' as const,
+            context: 'AllExceptionsFilter',
+            message: 'DB connection failed',
+            statusCode: 500,
+            method: 'GET',
+            path: '/api/platform-admin/system-health',
+        };
+
+        expect(service.buildDeduplicationKey(baseRequest)).toBe(
+            service.buildDeduplicationKey({ ...baseRequest, timestamp: new Date() }),
+        );
+    });
+});

--- a/src/common/discord/domain/services/discord-error-alert-policy.service.ts
+++ b/src/common/discord/domain/services/discord-error-alert-policy.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+
+import type { DiscordErrorAlertRequest } from '../../application/ports/discord-error-alert.port';
+
+/**
+ * Discord 에러 알림 정책 서비스
+ *
+ * 어떤 에러를 운영 알림으로 보낼지와 중복 알림 기준을 결정합니다.
+ */
+@Injectable()
+export class DiscordErrorAlertPolicyService {
+    /** 같은 에러는 기본 5분 동안 재전송하지 않습니다. */
+    private static readonly DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+
+    /**
+     * Discord 알림 대상 여부를 판단합니다.
+     *
+     * 4xx 계열 요청 오류는 사용자 입력/인증/봇 스캔일 가능성이 높아 제외하고,
+     * 5xx 또는 HTTP 상태 코드가 없는 인프라/애플리케이션 에러만 알림 대상으로 봅니다.
+     */
+    shouldNotify(request: DiscordErrorAlertRequest): boolean {
+        if (!request.context || !request.message) {
+            return false;
+        }
+
+        if (request.statusCode && request.statusCode < 500) {
+            return false;
+        }
+
+        return request.severity === 'critical' || request.severity === 'error';
+    }
+
+    /**
+     * 중복 알림 방지 키를 생성합니다.
+     */
+    buildDeduplicationKey(request: DiscordErrorAlertRequest): string {
+        const normalizedMessage = request.message.replace(/\s+/g, ' ').trim().slice(0, 180);
+
+        return [
+            request.context,
+            request.statusCode ?? 'no-status',
+            request.method ?? 'no-method',
+            request.path ?? 'no-path',
+            normalizedMessage,
+        ].join('|');
+    }
+
+    /**
+     * 중복 알림 쿨다운 시간을 반환합니다.
+     */
+    getCooldownMs(): number {
+        return DiscordErrorAlertPolicyService.DEFAULT_COOLDOWN_MS;
+    }
+}

--- a/src/common/discord/infrastructure/discord-error-alert.adapter.spec.ts
+++ b/src/common/discord/infrastructure/discord-error-alert.adapter.spec.ts
@@ -1,0 +1,84 @@
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+
+import { DiscordErrorAlertAdapter } from './discord-error-alert.adapter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
+
+jest.mock('axios');
+
+describe('DiscordErrorAlertAdapter', () => {
+    const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+    let configService: { get: jest.Mock };
+    let logger: jest.Mocked<Pick<CustomLoggerService, 'logWarning' | 'logSuccess'>>;
+
+    beforeEach(() => {
+        mockedAxios.post.mockResolvedValue({ data: {} });
+        configService = {
+            get: jest.fn((key: string) => {
+                if (key === 'DISCORD_ERROR_WEBHOOK_URL') return 'https://discord.test/error-webhook';
+                return undefined;
+            }),
+        };
+        logger = {
+            logWarning: jest.fn(),
+            logSuccess: jest.fn(),
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('critical 에러를 Discord Webhook embed payload로 전송해야 한다', async () => {
+        const adapter = new DiscordErrorAlertAdapter(
+            configService as unknown as ConfigService,
+            logger as unknown as CustomLoggerService,
+        );
+
+        await adapter.sendCriticalErrorAlert({
+            severity: 'critical',
+            context: 'AllExceptionsFilter',
+            message: 'DB connection failed',
+            statusCode: 500,
+            method: 'GET',
+            path: '/api/test',
+            timestamp: new Date('2026-04-16T00:00:00.000Z'),
+        });
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            'https://discord.test/error-webhook',
+            expect.objectContaining({
+                embeds: [
+                    expect.objectContaining({
+                        title: '🚨 Critical 서버 에러',
+                        color: 0xf44336,
+                        description: 'DB connection failed',
+                        timestamp: '2026-04-16T00:00:00.000Z',
+                    }),
+                ],
+            }),
+        );
+        expect(logger.logSuccess).toHaveBeenCalled();
+    });
+
+    it('에러 웹훅 URL이 없으면 HTTP 요청 없이 경고 로그만 남겨야 한다', async () => {
+        configService.get.mockReturnValue(undefined);
+        const adapter = new DiscordErrorAlertAdapter(
+            configService as unknown as ConfigService,
+            logger as unknown as CustomLoggerService,
+        );
+
+        await adapter.sendCriticalErrorAlert({
+            severity: 'critical',
+            context: 'AllExceptionsFilter',
+            message: 'DB connection failed',
+        });
+
+        expect(mockedAxios.post).not.toHaveBeenCalled();
+        expect(logger.logWarning).toHaveBeenCalledWith(
+            'sendCriticalErrorAlert',
+            '디스코드 에러 웹훅이 설정되지 않아 알림을 보낼 수 없습니다.',
+        );
+    });
+});

--- a/src/common/discord/infrastructure/discord-error-alert.adapter.ts
+++ b/src/common/discord/infrastructure/discord-error-alert.adapter.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+import { CustomLoggerService } from '../../logger/custom-logger.service';
+import type { DiscordErrorAlertPort, DiscordErrorAlertRequest } from '../application/ports/discord-error-alert.port';
+
+/**
+ * Discord Webhook 에러 알림 Adapter
+ *
+ * Discord Webhook HTTP API 호출 책임만 담당합니다.
+ */
+@Injectable()
+export class DiscordErrorAlertAdapter implements DiscordErrorAlertPort {
+    private readonly errorWebhookUrl: string;
+
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly logger: CustomLoggerService,
+    ) {
+        this.errorWebhookUrl =
+            this.configService.get<string>('DISCORD_ERROR_WEBHOOK_URL') ||
+            this.configService.get<string>('DISCORD_WEBHOOK_URL') ||
+            '';
+
+        if (!this.errorWebhookUrl) {
+            this.logger.logWarning('DiscordErrorAlertAdapter', '디스코드 에러 웹훅 URL이 설정되지 않았습니다.');
+        }
+    }
+
+    /**
+     * Critical 에러 알림을 Discord Webhook으로 전송합니다.
+     */
+    async sendCriticalErrorAlert(request: DiscordErrorAlertRequest): Promise<void> {
+        if (!this.errorWebhookUrl) {
+            this.logger.logWarning(
+                'sendCriticalErrorAlert',
+                '디스코드 에러 웹훅이 설정되지 않아 알림을 보낼 수 없습니다.',
+            );
+            return;
+        }
+
+        const timestamp = request.timestamp ?? new Date();
+        const title = request.severity === 'critical' ? '🚨 Critical 서버 에러' : '⚠️ 서버 에러';
+        const fields = this.buildFields(request);
+
+        await axios.post(this.errorWebhookUrl, {
+            embeds: [
+                {
+                    title,
+                    color: request.severity === 'critical' ? 0xf44336 : 0xff9800,
+                    description: this.truncate(request.message, 3500),
+                    fields,
+                    timestamp: timestamp.toISOString(),
+                    footer: {
+                        text: 'Pawpong Backend - Error Monitor',
+                    },
+                },
+            ],
+        });
+
+        this.logger.logSuccess('sendCriticalErrorAlert', 'Discord critical 에러 알림 전송 완료', {
+            context: request.context,
+            statusCode: request.statusCode,
+            path: request.path,
+        });
+    }
+
+    /**
+     * Discord embed field 목록을 생성합니다.
+     */
+    private buildFields(request: DiscordErrorAlertRequest): Array<{ name: string; value: string; inline: boolean }> {
+        const fields: Array<{ name: string; value: string; inline: boolean }> = [
+            { name: 'Context', value: request.context, inline: true },
+            { name: 'Severity', value: request.severity, inline: true },
+        ];
+
+        if (request.statusCode) {
+            fields.push({ name: 'Status', value: String(request.statusCode), inline: true });
+        }
+        if (request.method || request.path) {
+            fields.push({
+                name: 'Request',
+                value: this.truncate(`${request.method ?? '-'} ${request.path ?? '-'}`, 1024),
+                inline: false,
+            });
+        }
+        if (request.userId) {
+            fields.push({ name: 'User ID', value: request.userId, inline: true });
+        }
+        if (request.metadata && Object.keys(request.metadata).length > 0) {
+            fields.push({
+                name: 'Metadata',
+                value: this.truncate(JSON.stringify(request.metadata), 1024),
+                inline: false,
+            });
+        }
+        if (request.stack) {
+            fields.push({
+                name: 'Stack',
+                value: `\`\`\`\n${this.truncate(request.stack, 950)}\n\`\`\``,
+                inline: false,
+            });
+        }
+
+        return fields;
+    }
+
+    /**
+     * Discord embed 길이 제한에 맞춰 문자열을 자릅니다.
+     */
+    private truncate(value: string, maxLength: number): string {
+        if (value.length <= maxLength) {
+            return value;
+        }
+
+        return `${value.slice(0, maxLength - 3)}...`;
+    }
+}

--- a/src/common/filter/http-exception.filter.spec.ts
+++ b/src/common/filter/http-exception.filter.spec.ts
@@ -1,0 +1,94 @@
+import { ArgumentsHost, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+
+import { AllExceptionsFilter, HttpExceptionFilter } from './http-exception.filter';
+import { NotifyCriticalErrorUseCase } from '../discord/application/use-cases/notify-critical-error.use-case';
+
+describe('HttpExceptionFilter Discord 알림', () => {
+    let notifyCriticalErrorUseCase: jest.Mocked<Pick<NotifyCriticalErrorUseCase, 'execute'>>;
+
+    beforeEach(() => {
+        notifyCriticalErrorUseCase = {
+            execute: jest.fn().mockResolvedValue({ sent: true }),
+        };
+    });
+
+    it('HttpException 5xx는 critical 에러 알림 use-case로 전달해야 한다', () => {
+        const filter = new HttpExceptionFilter(notifyCriticalErrorUseCase as unknown as NotifyCriticalErrorUseCase);
+        const host = createHttpArgumentsHost();
+
+        filter.catch(new InternalServerErrorException('서버 오류'), host);
+
+        expect(notifyCriticalErrorUseCase.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                severity: 'critical',
+                context: 'HttpExceptionFilter',
+                statusCode: 500,
+                method: 'GET',
+                path: '/api/test',
+            }),
+        );
+    });
+
+    it('HttpException 4xx는 critical 에러 알림을 보내지 않아야 한다', () => {
+        const filter = new HttpExceptionFilter(notifyCriticalErrorUseCase as unknown as NotifyCriticalErrorUseCase);
+        const host = createHttpArgumentsHost();
+
+        filter.catch(new BadRequestException('잘못된 요청'), host);
+
+        expect(notifyCriticalErrorUseCase.execute).not.toHaveBeenCalled();
+    });
+});
+
+describe('AllExceptionsFilter Discord 알림', () => {
+    it('예상하지 못한 예외는 critical 에러 알림 use-case로 전달해야 한다', () => {
+        const notifyCriticalErrorUseCase = {
+            execute: jest.fn().mockResolvedValue({ sent: true }),
+        };
+        const filter = new AllExceptionsFilter(notifyCriticalErrorUseCase as unknown as NotifyCriticalErrorUseCase);
+        const host = createHttpArgumentsHost();
+
+        filter.catch(new Error('DB connection failed'), host);
+
+        expect(notifyCriticalErrorUseCase.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                severity: 'critical',
+                context: 'AllExceptionsFilter',
+                message: 'DB connection failed',
+                statusCode: 500,
+                method: 'GET',
+                path: '/api/test',
+            }),
+        );
+    });
+});
+
+/**
+ * ExceptionFilter 단위 테스트용 HTTP ArgumentsHost Mock을 생성합니다.
+ */
+function createHttpArgumentsHost(): ArgumentsHost {
+    const request = {
+        method: 'GET',
+        url: '/api/test',
+        originalUrl: '/api/test',
+        user: { userId: 'user-1' },
+    };
+    const response = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+    };
+
+    return {
+        switchToHttp: () => ({
+            getRequest: () => request,
+            getResponse: () => response,
+            getNext: jest.fn(),
+        }),
+        getArgByIndex: jest.fn(),
+        getArgs: jest.fn(),
+        getClass: jest.fn(),
+        getHandler: jest.fn(),
+        getType: jest.fn(),
+        switchToRpc: jest.fn(),
+        switchToWs: jest.fn(),
+    } as unknown as ArgumentsHost;
+}

--- a/src/common/filter/http-exception.filter.ts
+++ b/src/common/filter/http-exception.filter.ts
@@ -2,6 +2,7 @@ import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logge
 import { Request, Response } from 'express';
 
 import { ApiResponseDto } from '../dto/response/api-response.dto';
+import { NotifyCriticalErrorUseCase } from '../discord/application/use-cases/notify-critical-error.use-case';
 
 /**
  * HTTP 예외 필터
@@ -10,6 +11,8 @@ import { ApiResponseDto } from '../dto/response/api-response.dto';
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
     private readonly logger = new Logger(HttpExceptionFilter.name);
+
+    constructor(private readonly notifyCriticalErrorUseCase?: NotifyCriticalErrorUseCase) {}
 
     catch(exception: HttpException, host: ArgumentsHost) {
         const ctx = host.switchToHttp();
@@ -38,11 +41,38 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
         // 에러 로깅
         this.logger.error(`[${request.method}] ${request.url} - ${status} - ${errorMessage}`);
+        this.notifyCriticalError(exception, request, status, errorMessage);
 
         // ApiResponseDto 형식으로 응답
         const errorResponse = ApiResponseDto.error(errorMessage, status);
 
         response.status(status).json(errorResponse);
+    }
+
+    /**
+     * 5xx HTTP 예외만 Discord critical 에러 알림으로 전달합니다.
+     */
+    private notifyCriticalError(exception: HttpException, request: Request, status: number, message: string): void {
+        if (!this.notifyCriticalErrorUseCase || status < 500) {
+            return;
+        }
+
+        const requestUser = (request as Request & { user?: { userId?: string; sub?: string } }).user;
+
+        void this.notifyCriticalErrorUseCase
+            .execute({
+                severity: 'critical',
+                context: HttpExceptionFilter.name,
+                message,
+                statusCode: status,
+                method: request.method,
+                path: request.originalUrl ?? request.url,
+                stack: exception.stack,
+                userId: requestUser?.userId ?? requestUser?.sub,
+            })
+            .catch((error) => {
+                this.logger.error('[notifyCriticalError] Discord 에러 알림 실패', error.stack);
+            });
     }
 }
 
@@ -52,6 +82,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
     private readonly logger = new Logger(AllExceptionsFilter.name);
+
+    constructor(private readonly notifyCriticalErrorUseCase?: NotifyCriticalErrorUseCase) {}
 
     catch(exception: any, host: ArgumentsHost) {
         const ctx = host.switchToHttp();
@@ -64,10 +96,37 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
         // 에러 로깅
         this.logger.error(`[${request.method}] ${request.url} - ${status} - ${message}`, exception.stack);
+        this.notifyCriticalError(exception, request, status, message);
 
         // ApiResponseDto 형식으로 응답
         const errorResponse = ApiResponseDto.error(message, status);
 
         response.status(status).json(errorResponse);
+    }
+
+    /**
+     * 예상하지 못한 5xx 예외를 Discord critical 에러 알림으로 전달합니다.
+     */
+    private notifyCriticalError(exception: any, request: Request, status: number, message: string): void {
+        if (!this.notifyCriticalErrorUseCase || status < 500) {
+            return;
+        }
+
+        const requestUser = (request as Request & { user?: { userId?: string; sub?: string } }).user;
+
+        void this.notifyCriticalErrorUseCase
+            .execute({
+                severity: 'critical',
+                context: AllExceptionsFilter.name,
+                message,
+                statusCode: status,
+                method: request.method,
+                path: request.originalUrl ?? request.url,
+                stack: exception instanceof Error ? exception.stack : undefined,
+                userId: requestUser?.userId ?? requestUser?.sub,
+            })
+            .catch((error) => {
+                this.logger.error('[notifyCriticalError] Discord 에러 알림 실패', error.stack);
+            });
     }
 }

--- a/src/common/kafka/kafka.service.spec.ts
+++ b/src/common/kafka/kafka.service.spec.ts
@@ -1,0 +1,69 @@
+import { KafkaService } from './kafka.service';
+import { CustomLoggerService } from '../logger/custom-logger.service';
+import { NotifyCriticalErrorUseCase } from '../discord/application/use-cases/notify-critical-error.use-case';
+
+describe('KafkaService', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    let kafkaClient: { connect: jest.Mock; close: jest.Mock; emit: jest.Mock };
+    let logger: jest.Mocked<Pick<CustomLoggerService, 'logSuccess' | 'warn' | 'logWarning' | 'logDbOperation' | 'logError'>>;
+    let notifyCriticalErrorUseCase: jest.Mocked<Pick<NotifyCriticalErrorUseCase, 'execute'>>;
+
+    beforeEach(() => {
+        kafkaClient = {
+            connect: jest.fn(),
+            close: jest.fn(),
+            emit: jest.fn(),
+        };
+        logger = {
+            logSuccess: jest.fn(),
+            warn: jest.fn(),
+            logWarning: jest.fn(),
+            logDbOperation: jest.fn(),
+            logError: jest.fn(),
+        };
+        notifyCriticalErrorUseCase = {
+            execute: jest.fn().mockResolvedValue({ sent: true }),
+        };
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+    });
+
+    it('운영 환경에서 Kafka 연결 실패 시 critical 에러 알림을 요청해야 한다', async () => {
+        process.env.NODE_ENV = 'production';
+        kafkaClient.connect.mockRejectedValue(new Error('connect ECONNREFUSED kafka:29092'));
+
+        const service = new KafkaService(
+            kafkaClient as any,
+            logger as unknown as CustomLoggerService,
+            notifyCriticalErrorUseCase as unknown as NotifyCriticalErrorUseCase,
+        );
+
+        await service.onModuleInit();
+
+        expect(notifyCriticalErrorUseCase.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                severity: 'critical',
+                context: 'KafkaService',
+                message: expect.stringContaining('Kafka 브로커 연결 실패'),
+            }),
+        );
+    });
+
+    it('개발 환경에서 Kafka 연결 실패 시 Discord 알림을 보내지 않아야 한다', async () => {
+        process.env.NODE_ENV = 'development';
+        kafkaClient.connect.mockRejectedValue(new Error('connect ECONNREFUSED kafka:29092'));
+
+        const service = new KafkaService(
+            kafkaClient as any,
+            logger as unknown as CustomLoggerService,
+            notifyCriticalErrorUseCase as unknown as NotifyCriticalErrorUseCase,
+        );
+
+        await service.onModuleInit();
+
+        expect(notifyCriticalErrorUseCase.execute).not.toHaveBeenCalled();
+    });
+});

--- a/src/common/kafka/kafka.service.ts
+++ b/src/common/kafka/kafka.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Inject, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Inject, OnModuleInit, OnModuleDestroy, Optional } from '@nestjs/common';
 import { ClientKafka } from '@nestjs/microservices';
 import { CustomLoggerService } from '../logger/custom-logger.service';
+import { NotifyCriticalErrorUseCase } from '../discord/application/use-cases/notify-critical-error.use-case';
 
 /**
  * Kafka 토픽 정의
@@ -56,6 +57,7 @@ export class KafkaService implements OnModuleInit, OnModuleDestroy {
     constructor(
         @Inject('KAFKA_SERVICE') private readonly kafkaClient: ClientKafka,
         private readonly logger: CustomLoggerService,
+        @Optional() private readonly notifyCriticalErrorUseCase?: NotifyCriticalErrorUseCase,
     ) {}
 
     async onModuleInit() {
@@ -65,10 +67,11 @@ export class KafkaService implements OnModuleInit, OnModuleDestroy {
             await this.kafkaClient.connect();
             this.isConnected = true;
             this.logger.logSuccess('KafkaService', 'Kafka 브로커 연결 성공');
-        } catch {
+        } catch (error) {
             // Kafka 미연결 시 간단한 경고만 출력 (선택적 기능이므로 앱은 계속 동작)
             this.logger.warn('Kafka 미연결 - 채팅/이벤트 로깅 비활성화 (docker compose up kafka 필요)', 'KafkaService');
             this.isConnected = false;
+            this.notifyKafkaCriticalError('Kafka 브로커 연결 실패', error);
         }
     }
 
@@ -96,7 +99,30 @@ export class KafkaService implements OnModuleInit, OnModuleDestroy {
             this.logger.logDbOperation('KafkaService', 'emit', topic, { messageId: message.id });
         } catch (error) {
             this.logger.logError('KafkaService', `메시지 발행 실패: ${topic}`, error);
+            this.notifyKafkaCriticalError(`Kafka 메시지 발행 실패: ${topic}`, error, { topic });
         }
+    }
+
+    /**
+     * 운영 환경 Kafka 장애를 Discord critical 에러 알림으로 전달합니다.
+     *
+     * 로컬/테스트 환경에서는 Kafka를 일부러 끄는 경우가 많아 알림을 보내지 않습니다.
+     */
+    private notifyKafkaCriticalError(description: string, error: unknown, metadata?: Record<string, unknown>): void {
+        if (process.env.NODE_ENV !== 'production' || !this.notifyCriticalErrorUseCase) {
+            return;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const stack = error instanceof Error ? error.stack : undefined;
+
+        void this.notifyCriticalErrorUseCase.execute({
+            severity: 'critical',
+            context: KafkaService.name,
+            message: `${description}: ${errorMessage}`,
+            stack,
+            metadata,
+        });
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { HttpStatusInterceptor } from './common/interceptor/http-status.intercep
 import { LoggingInterceptor } from './common/interceptor/logging.interceptor';
 
 import { CustomLoggerService } from './common/logger/custom-logger.service';
+import { NotifyCriticalErrorUseCase } from './common/discord/application/use-cases/notify-critical-error.use-case';
 
 import { AppModule } from './app.module';
 
@@ -61,9 +62,10 @@ async function bootstrap(): Promise<void> {
         }),
     );
 
-    // 전역 예외 필터 적용 (ApiResponseDto 형식으로 에러 응답)
-    app.useGlobalFilters(new AllExceptionsFilter());
-    app.useGlobalFilters(new HttpExceptionFilter());
+    // 전역 예외 필터 적용 (ApiResponseDto 형식 응답 + critical 에러 Discord 알림)
+    const notifyCriticalErrorUseCase = app.get(NotifyCriticalErrorUseCase);
+    app.useGlobalFilters(new AllExceptionsFilter(notifyCriticalErrorUseCase));
+    app.useGlobalFilters(new HttpExceptionFilter(notifyCriticalErrorUseCase));
 
     // HTTP 상태 코드 통일 인터셉터 적용
     app.useGlobalInterceptors(new HttpStatusInterceptor());


### PR DESCRIPTION
## Summary

- 서버 critical 에러 발생 시 Discord `🚨서버에러` 채널로 알림을 전송하는 기능 추가
- 헥사고날 아키텍처(Port/Adapter) 기반으로 Discord 에러 알림 흐름 분리
- 5xx / unhandled exception / production Kafka 장애를 운영 알림 대상으로 처리
- 4xx, validation error, 인증 실패, 봇 스캔성 요청은 Discord 알림 대상에서 제외
- 동일 에러 반복 발생 시 Discord 도배를 막기 위한 5분 쿨다운 적용

## 주요 구현 내용

- Discord critical error alert 전용 구조 추가
  - `DiscordErrorAlertPort`
  - `NotifyCriticalErrorUseCase`
  - `DiscordErrorAlertPolicyService`
  - `DiscordErrorAlertAdapter`
- `DISCORD_ERROR_WEBHOOK_URL` 환경 변수 추가 대응
  - 에러 알림 전용 Discord Webhook URL
  - 값이 없을 경우 기존 `DISCORD_WEBHOOK_URL` fallback 지원
- 전역 예외 필터와 Discord 에러 알림 연결
  - `HttpExceptionFilter`: 5xx HTTP 예외만 알림 전송
  - `AllExceptionsFilter`: unhandled exception 알림 전송
- Kafka 장애 알림 추가
  - production 환경에서 Kafka 브로커 연결 실패 시 critical 알림
  - production 환경에서 Kafka 메시지 발행 실패 시 critical 알림
  - development/test 환경에서는 Kafka를 의도적으로 끄는 경우가 있어 알림 제외

## 알림 정책

- Discord 알림 대상
  - 5xx HTTP exception
  - unhandled exception
  - production Kafka connection failure
  - production Kafka publish failure

- Discord 알림 제외 대상
  - 400 validation error
  - 401/403 인증/권한 실패
  - 404
  - security probe / bot scan성 요청
  - development/test 환경 Kafka 미연결

## 운영 환경 반영

- 프로덕션 서버 `.env.production`에 아래 환경 변수 추가 완료

```env
DISCORD_ERROR_WEBHOOK_URL=...
