### PR TITLE
refactor(api): PUT -> PATCH 메서드 정정 

### DIFF
--- a/src/api/announcement/admin/announcement-admin-command.controller.ts
+++ b/src/api/announcement/admin/announcement-admin-command.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Param, Patch, Post } from '@nestjs/common';
 
 import { AnnouncementCreateRequestDto } from '../dto/request/announcement-create-request.dto';
 import { AnnouncementUpdateRequestDto } from '../dto/request/announcement-update-request.dto';
@@ -29,7 +29,7 @@ export class AnnouncementAdminCommandController {
         return result as AnnouncementResponseDto & AnnouncementResult;
     }
 
-    @Put('announcement/:announcementId')
+    @Patch('announcement/:announcementId')
     @ApiUpdateAnnouncementAdminEndpoint()
     async updateAnnouncement(
         @Param('announcementId') announcementId: string,

--- a/src/api/breeder-management/admin/breeder-management-admin-counsel-banners.controller.ts
+++ b/src/api/breeder-management/admin/breeder-management-admin-counsel-banners.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Get, Param, Patch, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { MongoObjectIdPipe } from '../../../common/pipe/mongo-object-id.pipe';
@@ -43,7 +43,7 @@ export class BreederManagementAdminCounselBannersController {
         return ApiResponseDto.success(banner, BREEDER_MANAGEMENT_RESPONSE_MESSAGES.counselBannerCreated);
     }
 
-    @Put('counsel-banner/:bannerId')
+    @Patch('counsel-banner/:bannerId')
     @ApiUpdateCounselBannerAdminEndpoint()
     async updateCounselBanner(
         @Param('bannerId', new MongoObjectIdPipe('배너', '올바르지 않은 배너 ID 형식입니다.')) bannerId: string,

--- a/src/api/breeder-management/admin/breeder-management-admin-profile-banners.controller.ts
+++ b/src/api/breeder-management/admin/breeder-management-admin-profile-banners.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Get, Param, Patch, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { MongoObjectIdPipe } from '../../../common/pipe/mongo-object-id.pipe';
@@ -43,7 +43,7 @@ export class BreederManagementAdminProfileBannersController {
         return ApiResponseDto.success(banner, BREEDER_MANAGEMENT_RESPONSE_MESSAGES.profileBannerCreated);
     }
 
-    @Put('profile-banner/:bannerId')
+    @Patch('profile-banner/:bannerId')
     @ApiUpdateProfileBannerAdminEndpoint()
     async updateProfileBanner(
         @Param('bannerId', new MongoObjectIdPipe('배너', '올바르지 않은 배너 ID 형식입니다.')) bannerId: string,

--- a/src/api/home/admin/home-admin-banners-command.controller.ts
+++ b/src/api/home/admin/home-admin-banners-command.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Param, Patch, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { CreateBannerUseCase } from './application/use-cases/create-banner.use-case';
@@ -26,7 +26,7 @@ export class HomeAdminBannersCommandController {
         return ApiResponseDto.success(banner, HOME_RESPONSE_MESSAGE_EXAMPLES.bannerCreated);
     }
 
-    @Put('banner/:bannerId')
+    @Patch('banner/:bannerId')
     @ApiUpdateBannerAdminEndpoint()
     async updateBanner(
         @Param('bannerId') bannerId: string,

--- a/src/api/home/admin/home-admin-faqs-command.controller.ts
+++ b/src/api/home/admin/home-admin-faqs-command.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Param, Patch, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { CreateFaqUseCase } from './application/use-cases/create-faq.use-case';
@@ -26,7 +26,7 @@ export class HomeAdminFaqsCommandController {
         return ApiResponseDto.success(faq, HOME_RESPONSE_MESSAGE_EXAMPLES.faqCreated);
     }
 
-    @Put('faq/:faqId')
+    @Patch('faq/:faqId')
     @ApiUpdateFaqAdminEndpoint()
     async updateFaq(
         @Param('faqId') faqId: string,

--- a/src/common/alimtalk/admin/alimtalk-admin.controller.ts
+++ b/src/common/alimtalk/admin/alimtalk-admin.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Delete, Get, Param, Patch, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../dto/response/api-response.dto';
 import { CreateAlimtalkTemplateUseCase } from './application/use-cases/create-alimtalk-template.use-case';
@@ -50,7 +50,7 @@ export class AlimtalkAdminController {
         return ApiResponseDto.success(data, ALIMTALK_ADMIN_RESPONSE_MESSAGES.templateDetailRetrieved);
     }
 
-    @Put('templates/:templateCode')
+    @Patch('templates/:templateCode')
     @ApiUpdateAlimtalkTemplateEndpoint()
     async updateTemplate(
         @Param('templateCode') templateCode: string,


### PR DESCRIPTION
## Summary
- 부분 수정 DTO에 @Put을 사용해 HTTP 스펙과 실제 동작이 불일치하던 어드민 엔드포인트 6개를 @Patch로 정정

## 주요 구현 내용
- 아래 6개 컨트롤러의 HTTP 메서드 변경 (@Put → @Patch)
   - announcement-admin-command.controller.ts
   - home-admin-banners-command.controller.ts
   - home-admin-faqs-command.controller.ts
   - breeder-management-admin-counsel-banners.controller.ts
   - breeder-management-admin-profile-banners.controller.ts
   - alimtalk-admin.controller.ts
- 각 컨트롤러의 import에서 Put 제거 후 Patch 추가

## 변경 이유
- PUT은 리소스 전체 교체(모든 필드 필수)를 의미하며 멱등성을 보장하는 메서드
- 위 6개 엔드포인트의 Update DTO는 모든 필드가 @IsOptional()로 선언되어 있어 실제 동작은 부분 수정(PATCH 시맨틱)
- HTTP 스펙과 실제 동작 간의 불일치를 정정

## 영향 범위
- Breaking Change: 프론트엔드에서 해당 6개 엔드포인트 호출 시 PUT → PATCH 메서드 변경 필요
- 비즈니스 로직, 응답 형식, DTO 변경 없음
