### PR TITLE
refactor(platform,alimtalk): @InjectModel 직접 주입 제거 및 헥사고날 계층 분리

### DIFF
--- a/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
+++ b/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
@@ -1,8 +1,7 @@
 import { Injectable, Inject, ForbiddenException } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
 
-import { Admin, AdminDocument } from '../../../../../schema/admin.schema';
+import { PLATFORM_ADMIN_READER_PORT } from '../ports/platform-admin-reader.port';
+import type { PlatformAdminReaderPort } from '../ports/platform-admin-reader.port';
 import { LOKI_QUERY_PORT } from '../ports/loki-query.port';
 import type { ILokiQueryPort } from '../ports/loki-query.port';
 import { LogCategorizerService } from '../../domain/services/log-categorizer.service';
@@ -21,7 +20,7 @@ import { SystemHealthFilterRequestDto } from '../../dto/request/system-health-fi
 @Injectable()
 export class GetSystemHealthUseCase {
     constructor(
-        @InjectModel(Admin.name) private readonly adminModel: Model<AdminDocument>,
+        @Inject(PLATFORM_ADMIN_READER_PORT) private readonly platformAdminReaderPort: PlatformAdminReaderPort,
         @Inject(LOKI_QUERY_PORT) private readonly lokiQueryPort: ILokiQueryPort,
         private readonly logCategorizerService: LogCategorizerService,
     ) {}
@@ -58,8 +57,8 @@ export class GetSystemHealthUseCase {
      * 관리자 통계 조회 권한을 확인합니다.
      */
     private async verifyAdminPermission(adminId: string): Promise<void> {
-        const admin = await this.adminModel.findById(adminId).lean();
-        if (!admin || !admin.permissions.canViewStatistics) {
+        const admin = await this.platformAdminReaderPort.findAdminById(adminId);
+        if (!admin || !admin.permissions?.canViewStatistics) {
             throw new ForbiddenException('시스템 헬스 조회 권한이 없습니다.');
         }
     }

--- a/src/common/alimtalk/alimtalk.module.ts
+++ b/src/common/alimtalk/alimtalk.module.ts
@@ -4,6 +4,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { AlimtalkService } from './alimtalk.service';
 import { ALIMTALK_SERVICE_TOKEN } from './alimtalk.token';
+import { AlimtalkTemplateRepository } from './repository/alimtalk-template.repository';
 
 import { AlimtalkTemplate, AlimtalkTemplateSchema } from '../../schema/alimtalk-template.schema';
 
@@ -36,6 +37,7 @@ import { AlimtalkTemplate, AlimtalkTemplateSchema } from '../../schema/alimtalk-
         MongooseModule.forFeature([{ name: AlimtalkTemplate.name, schema: AlimtalkTemplateSchema }]),
     ],
     providers: [
+        AlimtalkTemplateRepository,
         AlimtalkService,
         {
             provide: ALIMTALK_SERVICE_TOKEN,

--- a/src/common/alimtalk/alimtalk.service.ts
+++ b/src/common/alimtalk/alimtalk.service.ts
@@ -1,15 +1,10 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
 import CoolsmsMessageService from 'coolsms-node-sdk';
 
-import {
-    AlimtalkTemplate as AlimtalkTemplateSchema,
-    AlimtalkTemplateDocument,
-} from '../../schema/alimtalk-template.schema';
 import { AlimtalkTemplateCodeEnum } from '../../common/enum/alimtalk-template-code.enum';
 import { getErrorMessage, getErrorStack } from '../utils/error.util';
+import { AlimtalkTemplateRepository } from './repository/alimtalk-template.repository';
 
 /**
  * 템플릿 캐시용 인터페이스
@@ -84,8 +79,7 @@ export class AlimtalkService implements OnModuleInit {
 
     constructor(
         private readonly configService: ConfigService,
-        @InjectModel(AlimtalkTemplateSchema.name)
-        private readonly alimtalkTemplateModel: Model<AlimtalkTemplateDocument>,
+        private readonly alimtalkTemplateRepository: AlimtalkTemplateRepository,
     ) {
         this.suppressExternalWarnings =
             this.configService.get<string>('PAWPONG_SUPPRESS_EXTERNAL_WARNINGS') === 'true' ||
@@ -115,7 +109,7 @@ export class AlimtalkService implements OnModuleInit {
      */
     async refreshTemplateCache(): Promise<void> {
         try {
-            const templates = await this.alimtalkTemplateModel.find({ isActive: true }).lean().exec();
+            const templates = await this.alimtalkTemplateRepository.findAllActive();
 
             this.templateCache.clear();
             for (const template of templates) {
@@ -148,7 +142,7 @@ export class AlimtalkService implements OnModuleInit {
         }
 
         // 캐시에 없으면 DB 조회
-        const template = await this.alimtalkTemplateModel.findOne({ templateCode, isActive: true }).lean().exec();
+        const template = await this.alimtalkTemplateRepository.findActiveByCode(templateCode);
 
         if (template) {
             const cached: CachedTemplate = {

--- a/src/common/alimtalk/repository/alimtalk-template.repository.ts
+++ b/src/common/alimtalk/repository/alimtalk-template.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import {
+    AlimtalkTemplate,
+    AlimtalkTemplateDocument,
+} from '../../../schema/alimtalk-template.schema';
+
+@Injectable()
+export class AlimtalkTemplateRepository {
+    constructor(
+        @InjectModel(AlimtalkTemplate.name)
+        private readonly model: Model<AlimtalkTemplateDocument>,
+    ) {}
+
+    findAllActive() {
+        return this.model.find({ isActive: true }).lean().exec();
+    }
+
+    findActiveByCode(templateCode: string) {
+        return this.model.findOne({ templateCode, isActive: true }).lean().exec();
+    }
+}


### PR DESCRIPTION
## Summary
- Use Case 와 공통 서비스가 Moongoose Model 을 직접 주입받아 DB에 접근하던 헥사고날 아키텍처 위반 2건을 Port/Repository 경유로 정정

## 주요 구현 내용
**[심각도 높음] - `GetSystemHealthUseCase` - Port 경유로 전환**
- `@IngetModel(Admin.name)` 직접 주입 제거
- 기존에 선언된 `PLATFORM_ADMIN_READER_PORT` 의 `findAdminById( )` 경유로 교체
- Use Case 가 DB를 직접 알아야 할 이유 제거

**[심각도 중간] - AlimtalkService - Repository 분리**
- `@InjectModel(AlimtalkTemplate.name)` 직접 주입 제거
- `AlimtalkTemplateRepository` 신규 생성 (findAllActive, findActiveByCode)
- AlimtalkService는 Repository만 의존, Mongoose 완전 격리

## 변경 이유
- CLAUDE.md 아키텍처 원칙: Use Case는 Port만 알아야 하며, DB 접근은 Repository/Adapter 계층에 캡슐화해야 함
- 기존 코드는 `controller → use-case → port → adapter` 흐름을 무시하고 Use Case/Service가 Mongoose Model을 직접 호출하는 구조였음

## 영향 범위
- Breaking Change 없음 — 비즈니스 로직, API 응답, DTO 변경 없음
- E2E 25개 / 유닛 9개 전체 통과 확인