### PR TITLE
feat: FCM 푸시 알림 완성 — apns-environment 환경 분기 + 주요 이벤트 withPush 연결

### DIFF
--- a/src/api/adopter/infrastructure/adopter-application-notifier.adapter.ts
+++ b/src/api/adopter/infrastructure/adopter-application-notifier.adapter.ts
@@ -43,6 +43,7 @@ export class AdopterApplicationNotifierAdapter implements AdopterApplicationNoti
             });
         }
 
+        builder.withPush();
         await builder.send();
     }
 
@@ -69,6 +70,7 @@ export class AdopterApplicationNotifierAdapter implements AdopterApplicationNoti
             });
         }
 
+        builder.withPush();
         await builder.send();
     }
 }

--- a/src/api/breeder/admin/infrastructure/breeder-admin-notifier.adapter.ts
+++ b/src/api/breeder/admin/infrastructure/breeder-admin-notifier.adapter.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { RecipientType } from '../../../../common/enum/user.enum';
+import { NotificationType, RecipientType } from '../../../../common/enum/user.enum';
 import { MailService } from '../../../../common/mail/mail.service';
 import { MailTemplateService } from '../../../../common/mail/mail-template.service';
 import { getErrorStack } from '../../../../common/utils/error.util';
@@ -26,18 +26,23 @@ export class BreederAdminNotifierAdapter implements BreederAdminNotifierPort {
     ) {}
 
     async sendSuspensionEmail(recipient: BreederAdminNotificationRecipient, reason: string): Promise<void> {
-        if (!recipient.emailAddress) {
-            return;
-        }
+        const builder = this.notificationDispatchPort
+            .to(recipient.breederId, RecipientType.BREEDER)
+            .type(NotificationType.BREEDER_SUSPENDED)
+            .title('브리더 계정이 정지되었습니다')
+            .content('자세한 사유는 이메일을 확인해주세요.');
 
-        const emailContent = this.mailTemplateService.getBreederSuspensionEmail(recipient.breederName, reason);
-        void this.mailService
-            .sendMail({
+        if (recipient.emailAddress) {
+            const emailContent = this.mailTemplateService.getBreederSuspensionEmail(recipient.breederName, reason);
+            builder.withEmail({
                 to: recipient.emailAddress,
                 subject: emailContent.subject,
                 html: emailContent.html,
-            })
-            .catch((error: unknown) => this.logger.error('브리더 정지 이메일 발송 실패', getErrorStack(error)));
+            });
+        }
+
+        builder.withPush();
+        await builder.send();
     }
 
     async sendUnsuspensionEmail(recipient: BreederAdminNotificationRecipient): Promise<void> {
@@ -72,6 +77,7 @@ export class BreederAdminNotifierAdapter implements BreederAdminNotifierPort {
             });
         }
 
+        builder.withPush();
         await builder.send();
     }
 

--- a/src/api/breeder/admin/verification/infrastructure/breeder-verification-admin-notifier.adapter.ts
+++ b/src/api/breeder/admin/verification/infrastructure/breeder-verification-admin-notifier.adapter.ts
@@ -36,6 +36,7 @@ export class BreederVerificationAdminNotifierAdapter implements BreederVerificat
             });
         }
 
+        builder.withPush();
         await builder.send();
     }
 
@@ -64,27 +65,28 @@ export class BreederVerificationAdminNotifierAdapter implements BreederVerificat
             });
         }
 
+        builder.withPush();
         await builder.send();
     }
 
     async sendDocumentReminder(recipient: BreederVerificationAdminNotificationRecipient): Promise<void> {
-        if (!recipient.emailAddress) {
-            return;
-        }
-
-        const emailContent = this.mailTemplateService.getDocumentReminderEmail(recipient.breederName);
-
-        await this.notificationDispatchPort
+        const builder = this.notificationDispatchPort
             .to(recipient.breederId, RecipientType.BREEDER)
             .type(NotificationType.DOCUMENT_REMINDER)
             .title('🐾 브리더 입점 절차가 아직 완료되지 않았어요!')
             .content('필요한 서류들을 제출하시면 입양자에게 프로필이 공개됩니다.')
-            .related(recipient.breederId, 'profile')
-            .withEmail({
+            .related(recipient.breederId, 'profile');
+
+        if (recipient.emailAddress) {
+            const emailContent = this.mailTemplateService.getDocumentReminderEmail(recipient.breederName);
+            builder.withEmail({
                 to: recipient.emailAddress,
                 subject: emailContent.subject,
                 html: emailContent.html,
-            })
-            .send();
+            });
+        }
+
+        builder.withPush();
+        await builder.send();
     }
 }

--- a/src/api/notification/infrastructure/notification-firebase-push.adapter.ts
+++ b/src/api/notification/infrastructure/notification-firebase-push.adapter.ts
@@ -76,6 +76,10 @@ export class NotificationFirebasePushAdapter implements NotificationPushPort, On
                     },
                 },
                 apns: {
+                    headers: {
+                        // iOS 개발 빌드(debug)는 sandbox APNs, 배포 빌드는 production APNs 사용
+                        'apns-environment': this.configService.get('NODE_ENV') === 'production' ? 'production' : 'sandbox',
+                    },
                     payload: {
                         aps: {
                             sound: 'default',


### PR DESCRIPTION
## Summary
- iOS 개발 빌드에서 FCM 푸시가 도달하지 않던 원인(`apns-environment` 누락) 수정
- DB 알림은 생성되나 FCM 푸시가 누락된 주요 이벤트 5종에 푸시 연결

## 주요 구현 내용

**[버그 수정] `notification-firebase-push.adapter` — apns-environment 환경 분기**
- `NODE_ENV=production`이면 `production` APNs, 그 외엔 `sandbox` APNs 사용
- 기존에는 헤더 미설정 → FCM이 production APNs로 전송 → 개발 빌드(sandbox 토큰)에서 푸시 미도달

**[기능 추가] 주요 이벤트 FCM 푸시 연결 (withPush 추가)**
- `NEW_CONSULT_REQUEST` — 브리더에게 상담 신청 수신 알림
- `CONSULT_REQUEST_CONFIRMED` — 입양자에게 상담 확정 알림
- `BREEDER_APPROVED` / `BREEDER_REJECTED` — 브리더 승인/반려 알림
- `DOCUMENT_REMINDER` — 브리더 서류 미제출 리마인드
- `BREEDER_SUSPENDED` — 브리더 계정 정지 알림 (기존 이메일만 → DB 저장 + 푸시 추가)

## 변경 이유
- `test-push.mjs`로 FCM 인프라 연결은 확인됐으나 백엔드 실서비스 알림 경로에 두 가지 누락 발견
- `apns-environment: sandbox` 미설정으로 개발 빌드에서 푸시 수신 불가
- 대부분의 이벤트가 DB 알림 저장만 하고 FCM 발송을 하지 않던 상태

## 영향 범위
- Breaking Change 없음 — API 응답, DTO 무변경
- 알림 도달률 향상 (앱 외부에서도 주요 이벤트 인지 가능)
- `BREEDER_SUSPENDED`는 기존 이메일 전용에서 DB 알림 + 이메일 + FCM 푸시로 확장

## Test plan
- [x] `yarn typecheck` 통과
- [x] `yarn test --testPathPatterns="src/api/notification" --runInBand` 통과 (72개)
- [ ] dev 서버 배포 후 Xcode debug 빌드에서 FCM 푸시 수신 확인