### PR TITLE
fix(notification): push-token 등록 시 platform 필드 optional 처리

### DIFF
--- a/src/api/adopter/repository/adopter.repository.ts
+++ b/src/api/adopter/repository/adopter.repository.ts
@@ -300,13 +300,13 @@ export class AdopterRepository {
      *
      * @param adopterId 입양자 ID
      * @param token FCM 디바이스 토큰
-     * @param platform 디바이스 플랫폼 (ios/android)
+     * @param platform 디바이스 플랫폼 (ios/android, 웹 브릿지 경유 시 생략 가능)
      * @param appVersion 선택적 앱 버전 (디버깅용)
      */
     async upsertPushDeviceToken(
         adopterId: string,
         token: string,
-        platform: 'ios' | 'android',
+        platform?: 'ios' | 'android',
         appVersion?: string,
     ): Promise<void> {
         await this.adopterModel.updateOne({ _id: adopterId }, { $pull: { pushDeviceTokens: { token } } }).exec();

--- a/src/api/breeder-management/repository/breeder.repository.ts
+++ b/src/api/breeder-management/repository/breeder.repository.ts
@@ -386,13 +386,13 @@ export class BreederRepository {
      *
      * @param breederId 브리더 ID
      * @param token FCM 디바이스 토큰
-     * @param platform 디바이스 플랫폼
+     * @param platform 디바이스 플랫폼 (웹 브릿지 경유 시 생략 가능)
      * @param appVersion 선택적 앱 버전 (디버깅용)
      */
     async upsertPushDeviceToken(
         breederId: string,
         token: string,
-        platform: 'ios' | 'android',
+        platform?: 'ios' | 'android',
         appVersion?: string,
     ): Promise<void> {
         await this.breederModel.updateOne({ _id: breederId }, { $pull: { pushDeviceTokens: { token } } }).exec();

--- a/src/api/notification/application/ports/notification-push-token-store.port.ts
+++ b/src/api/notification/application/ports/notification-push-token-store.port.ts
@@ -9,7 +9,7 @@ export interface RegisterPushDeviceTokenCommand {
     userId: string;
     userRole: NotificationUserRole;
     token: string;
-    platform: 'ios' | 'android';
+    platform?: 'ios' | 'android';
     appVersion?: string;
 }
 

--- a/src/api/notification/dto/request/register-push-device-token-request.dto.ts
+++ b/src/api/notification/dto/request/register-push-device-token-request.dto.ts
@@ -14,13 +14,15 @@ export class RegisterPushDeviceTokenRequestDto {
     token: string;
 
     @ApiProperty({
-        description: '디바이스 플랫폼',
+        description: '디바이스 플랫폼 (웹 브릿지 경유 시 생략 가능)',
         enum: ['ios', 'android'],
         example: 'ios',
+        required: false,
     })
+    @IsOptional()
     @IsString()
     @IsIn(['ios', 'android'])
-    platform: 'ios' | 'android';
+    platform?: 'ios' | 'android';
 
     @ApiProperty({
         description: '앱 버전 (디버깅용)',

--- a/src/schema/user.schema.ts
+++ b/src/schema/user.schema.ts
@@ -14,9 +14,10 @@ export class PushDeviceToken {
 
     /**
      * 디바이스 플랫폼 (ios | android)
+     * 웹 브릿지를 통한 토큰 등록 시 플랫폼 정보가 없을 수 있어 optional 처리
      */
-    @Prop({ required: true, enum: ['ios', 'android'] })
-    platform: string;
+    @Prop({ required: false, enum: ['ios', 'android'] })
+    platform?: string;
 
     /**
      * 토큰 등록/갱신 시각 (FCM은 주기적 갱신 필요)


### PR DESCRIPTION
## Summary
- `POST /api/notification/push-token` 등록 시 `platform` 필드 optional 처리
- 웹→RN 브릿지 경유 토큰 등록 흐름 호환성 확보

## 주요 구현 내용

**[호환성 수정] push-token 등록 API — platform 필드 optional 처리**
- 프론트(Next.js)가 RN 브릿지로 FCM 토큰을 받아 백엔드에 등록하는 구조상
  platform 정보 없이 `{ token }` 만 전송 → 기존 required 검증에서 400 발생
- schema / port command / DTO / adopter·breeder repository 전 레이어 optional 처리

**변경 파일**
- `user.schema.ts` — `PushDeviceToken.platform` `required: false`
- `notification-push-token-store.port.ts` — `RegisterPushDeviceTokenCommand.platform?`
- `register-push-device-token-request.dto.ts` — `@IsOptional()` 추가
- `adopter.repository.ts` — `upsertPushDeviceToken` 시그니처 `platform?`
- `breeder.repository.ts` — 동일

## 변경 이유
- 프론트 브릿지 구현 완료 (dev.pawpong.kr 배포) 후
  push-token 등록 엔드포인트가 400을 반환하던 상태 수정
- RN 직접 등록 흐름(platform 포함)은 기존과 동일하게 동작

## 영향 범위
- Breaking Change 없음 — API 응답, DTO 계약 무변경
- platform 미포함 요청도 토큰 저장 정상 처리

## Test plan
- [x] `yarn typecheck` 통과
- [ ] dev 서버 배포 후 로그인 시 push-token 등록 요청 200 확인