### PR TITLE
fix(adoption): v2 입양 상세 컴파일 회복 + 브리더 요약 정책 정렬

### DIFF
--- a/src/api/adoption/adoption.module-definition.ts
+++ b/src/api/adoption/adoption.module-definition.ts
@@ -4,7 +4,9 @@ import { StorageModule } from '../../common/storage/storage.module';
 import { AdopterPetFavorite, AdopterPetFavoriteSchema } from '../../schema/adopter-pet-favorite.schema';
 import { AdoptionApplication, AdoptionApplicationSchema } from '../../schema/adoption-application.schema';
 import { AvailablePet, AvailablePetSchema } from '../../schema/available-pet.schema';
+import { Breeder, BreederSchema } from '../../schema/breeder.schema';
 
+import { AdoptionDetailController } from './controller/adoption-detail.controller';
 import { AdoptionFavoriteController } from './controller/adoption-favorite.controller';
 import { AdoptionListController } from './controller/adoption-list.controller';
 import { AdoptionMyAdoptedController } from './controller/adoption-my-adopted.controller';
@@ -14,9 +16,12 @@ import {
     ADOPTER_PET_FAVORITE_WRITER_PORT,
 } from './application/ports/adopter-pet-favorite.port';
 import { ADOPTION_ASSET_URL_PORT } from './application/ports/adoption-asset-url.port';
+import { ADOPTION_BREEDER_SUMMARY_PORT } from './application/ports/adoption-breeder-summary.port';
 import { ADOPTION_PET_READER_PORT } from './application/ports/adoption-pet-reader.port';
+import { ADOPTION_PET_WRITER_PORT } from './application/ports/adoption-pet-writer.port';
 import { ADOPTION_RECORD_READER_PORT } from './application/ports/adoption-record-reader.port';
 import { AddAdoptionPetFavoriteUseCase } from './application/use-cases/add-adoption-pet-favorite.use-case';
+import { GetAdoptionPetDetailUseCase } from './application/use-cases/get-adoption-pet-detail.use-case';
 import { GetAdoptionPetListUseCase } from './application/use-cases/get-adoption-pet-list.use-case';
 import { GetMyAdoptedListUseCase } from './application/use-cases/get-my-adopted-list.use-case';
 import { GetMyAdoptionFavoritesUseCase } from './application/use-cases/get-my-adoption-favorites.use-case';
@@ -24,7 +29,9 @@ import { GetPopularAdoptionPetsUseCase } from './application/use-cases/get-popul
 import { RemoveAdoptionPetFavoriteUseCase } from './application/use-cases/remove-adoption-pet-favorite.use-case';
 import { AdoptionPetMapperService } from './domain/services/adoption-pet-mapper.service';
 import { AdopterPetFavoriteMongooseAdapter } from './infrastructure/adopter-pet-favorite-mongoose.adapter';
+import { AdoptionBreederSummaryMongooseAdapter } from './infrastructure/adoption-breeder-summary-mongoose.adapter';
 import { AdoptionPetMongooseReaderAdapter } from './infrastructure/adoption-pet-mongoose-reader.adapter';
+import { AdoptionPetMongooseWriterAdapter } from './infrastructure/adoption-pet-mongoose-writer.adapter';
 import { AdoptionRecordMongooseReaderAdapter } from './infrastructure/adoption-record-mongoose-reader.adapter';
 import { AdoptionStorageAssetUrlAdapter } from './infrastructure/adoption-storage-asset-url.adapter';
 import { AdopterPetFavoriteRepository } from './repository/adopter-pet-favorite.repository';
@@ -35,12 +42,14 @@ const SCHEMA_IMPORTS = MongooseModule.forFeature([
     { name: AvailablePet.name, schema: AvailablePetSchema },
     { name: AdopterPetFavorite.name, schema: AdopterPetFavoriteSchema },
     { name: AdoptionApplication.name, schema: AdoptionApplicationSchema },
+    { name: Breeder.name, schema: BreederSchema },
 ]);
 
 export const ADOPTION_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule];
 
 export const ADOPTION_MODULE_CONTROLLERS = [
     AdoptionListController,
+    AdoptionDetailController,
     AdoptionFavoriteController,
     AdoptionMyFavoritesController,
     AdoptionMyAdoptedController,
@@ -49,6 +58,7 @@ export const ADOPTION_MODULE_CONTROLLERS = [
 const USE_CASE_PROVIDERS = [
     GetAdoptionPetListUseCase,
     GetPopularAdoptionPetsUseCase,
+    GetAdoptionPetDetailUseCase,
     AddAdoptionPetFavoriteUseCase,
     RemoveAdoptionPetFavoriteUseCase,
     GetMyAdoptionFavoritesUseCase,
@@ -62,6 +72,8 @@ const INFRASTRUCTURE_PROVIDERS = [
     AdopterPetFavoriteRepository,
     AdoptionRecordRepository,
     AdoptionPetMongooseReaderAdapter,
+    AdoptionPetMongooseWriterAdapter,
+    AdoptionBreederSummaryMongooseAdapter,
     AdopterPetFavoriteMongooseAdapter,
     AdoptionRecordMongooseReaderAdapter,
     AdoptionStorageAssetUrlAdapter,
@@ -69,6 +81,8 @@ const INFRASTRUCTURE_PROVIDERS = [
 
 const PORT_BINDINGS = [
     { provide: ADOPTION_PET_READER_PORT, useExisting: AdoptionPetMongooseReaderAdapter },
+    { provide: ADOPTION_PET_WRITER_PORT, useExisting: AdoptionPetMongooseWriterAdapter },
+    { provide: ADOPTION_BREEDER_SUMMARY_PORT, useExisting: AdoptionBreederSummaryMongooseAdapter },
     { provide: ADOPTER_PET_FAVORITE_READER_PORT, useExisting: AdopterPetFavoriteMongooseAdapter },
     { provide: ADOPTER_PET_FAVORITE_WRITER_PORT, useExisting: AdopterPetFavoriteMongooseAdapter },
     { provide: ADOPTION_ASSET_URL_PORT, useExisting: AdoptionStorageAssetUrlAdapter },

--- a/src/api/adoption/application/ports/adoption-pet-reader.port.ts
+++ b/src/api/adoption/application/ports/adoption-pet-reader.port.ts
@@ -4,6 +4,8 @@ export type AdoptionPetSort = 'latest' | 'popular';
 
 export type AdoptionPetListQuery = {
     petType?: AdoptionPetType;
+    breederId?: string;
+    excludePetId?: string;
     sort: AdoptionPetSort;
     skip: number;
     limit: number;
@@ -28,12 +30,44 @@ export type AdoptionPetSnapshot = {
     updatedAt: Date;
 };
 
+/**
+ * v2 입양 상세 화면 (Figma 39:1240) 응답 조립용 확장 스냅샷.
+ * 일반 카드 스냅샷에 건강/부모/사육환경/태그/소개 등 상세 필드를 추가한다.
+ */
+export type AdoptionPetDetailSnapshot = AdoptionPetSnapshot & {
+    description?: string;
+    tags?: string[];
+    representativePhotoIndex?: number;
+    vaccinationStatus?: 'completed' | 'incomplete';
+    vaccinationRecords?: Array<{ name: string; date: Date; round: number }>;
+    vaccinationIncompleteReason?: string;
+    geneticTestStatus?: 'completed' | 'incomplete';
+    geneticTestRecords?: Array<{ date: Date; institution: string; testName: string; result: string }>;
+    geneticTestIncompleteReason?: string;
+    parentPetSnapshots?: Array<{
+        relation: 'mother' | 'father';
+        breed: string;
+        name: string;
+        birthDate?: Date;
+        photoFileName?: string;
+    }>;
+    breedingEnvironment?: {
+        description?: string;
+        photoFileName?: string;
+    };
+};
+
 export const ADOPTION_PET_READER_PORT = Symbol('ADOPTION_PET_READER_PORT');
 
 export interface AdoptionPetReaderPort {
-    countList(query: Pick<AdoptionPetListQuery, 'petType'>): Promise<number>;
+    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number>;
     readList(query: AdoptionPetListQuery): Promise<AdoptionPetSnapshot[]>;
     readPopular(petType: AdoptionPetType | undefined, limit: number): Promise<AdoptionPetSnapshot[]>;
     readById(petId: string): Promise<AdoptionPetSnapshot | null>;
+    /**
+     * 입양 상세용 — base snapshot 에 건강/부모/사육환경 등 추가 필드 포함.
+     * isActive=false 항목은 null 을 반환한다.
+     */
+    readByIdDetailed(petId: string): Promise<AdoptionPetDetailSnapshot | null>;
     incrementFavoriteCount(petId: string, delta: number): Promise<void>;
 }

--- a/src/api/adoption/application/types/adoption-result.type.ts
+++ b/src/api/adoption/application/types/adoption-result.type.ts
@@ -23,3 +23,37 @@ export type AdoptionPetItemResult = {
 };
 
 export type AdoptionPetListResult = PageResult<AdoptionPetItemResult>;
+
+/**
+ * v2 입양 상세 응답 (Figma 39:1240).
+ * 카드 응답 + 건강/부모/사육환경/태그/소개/브리더 요약을 포함.
+ */
+export type AdoptionPetDetailResult = AdoptionPetItemResult & {
+    description?: string;
+    tags: string[];
+    birthDate: string;
+    vaccinationStatus?: 'completed' | 'incomplete';
+    vaccinationRecords: Array<{ name: string; date: string; round: number }>;
+    vaccinationIncompleteReason?: string;
+    geneticTestStatus?: 'completed' | 'incomplete';
+    geneticTestRecords: Array<{ date: string; institution: string; testName: string; result: string }>;
+    geneticTestIncompleteReason?: string;
+    parents: Array<{
+        relation: 'mother' | 'father';
+        breed: string;
+        name: string;
+        birthDate?: string;
+        photoUrl?: string;
+    }>;
+    breedingEnvironment?: {
+        description?: string;
+        photoUrl?: string;
+    };
+    breeder: {
+        breederId: string;
+        displayName: string;
+        profileImageUrl?: string;
+        locationText?: string;
+        bpm: number;
+    };
+};

--- a/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
+++ b/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
@@ -32,6 +32,8 @@ export class GetAdoptionPetListUseCase {
 
     async execute(input: {
         petType?: AdoptionPetSnapshot['petType'];
+        breederId?: string;
+        excludePetId?: string;
         sort?: AdoptionPetListQuery['sort'];
         page?: number;
         pageSize?: number;
@@ -43,13 +45,19 @@ export class GetAdoptionPetListUseCase {
 
         const query: AdoptionPetListQuery = {
             petType: input.petType,
+            breederId: input.breederId,
+            excludePetId: input.excludePetId,
             sort,
             skip: (page - 1) * pageSize,
             limit: pageSize,
         };
 
         const [totalItems, snapshots] = await Promise.all([
-            this.petReader.countList({ petType: input.petType }),
+            this.petReader.countList({
+                petType: input.petType,
+                breederId: input.breederId,
+                excludePetId: input.excludePetId,
+            }),
             this.petReader.readList(query),
         ]);
 
@@ -57,10 +65,7 @@ export class GetAdoptionPetListUseCase {
         return buildPageResult(items, page, pageSize, totalItems);
     }
 
-    private async toItems(
-        snapshots: AdoptionPetSnapshot[],
-        adopterId?: string,
-    ): Promise<AdoptionPetItemResult[]> {
+    private async toItems(snapshots: AdoptionPetSnapshot[], adopterId?: string): Promise<AdoptionPetItemResult[]> {
         if (snapshots.length === 0) {
             return [];
         }

--- a/src/api/adoption/constants/adoption-response-messages.ts
+++ b/src/api/adoption/constants/adoption-response-messages.ts
@@ -1,6 +1,7 @@
 export const ADOPTION_RESPONSE_MESSAGE_EXAMPLES = {
     listRetrieved: '입양 가능 동물 목록 조회 성공',
     popularRetrieved: '인기 입양 동물 조회 성공',
+    detailRetrieved: '입양 동물 상세 조회 성공',
     favoriteAdded: '관심 동물로 등록되었습니다.',
     favoriteRemoved: '관심 동물이 해제되었습니다.',
     myFavoritesRetrieved: '입양 관심 목록 조회 성공',

--- a/src/api/adoption/controller/adoption-detail.controller.ts
+++ b/src/api/adoption/controller/adoption-detail.controller.ts
@@ -1,0 +1,29 @@
+import { Get, Param } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { MongoObjectIdPipe } from '../../../common/pipe/mongo-object-id.pipe';
+import { GetAdoptionPetDetailUseCase } from '../application/use-cases/get-adoption-pet-detail.use-case';
+import { ADOPTION_RESPONSE_MESSAGE_EXAMPLES } from '../constants/adoption-response-messages';
+import { AdoptionOptionalAuthController } from '../decorator/adoption-protected-controller.decorator';
+import { AdoptionPetDetailResponseDto } from '../dto/response/adoption-pet-detail-response.dto';
+import { ApiGetAdoptionDetailEndpoint } from '../swagger';
+
+/**
+ * 입양 동물 상세 (Figma 39:1240) — 공개, 로그인 시 isFavorited 채움.
+ * GET 요청 시 viewCount 가 원자적으로 +1 증가한다.
+ */
+@AdoptionOptionalAuthController()
+export class AdoptionDetailController {
+    constructor(private readonly getAdoptionPetDetailUseCase: GetAdoptionPetDetailUseCase) {}
+
+    @Get(':petId')
+    @ApiGetAdoptionDetailEndpoint()
+    async getDetail(
+        @Param('petId', new MongoObjectIdPipe('동물')) petId: string,
+        @CurrentUser('userId') userId?: string,
+    ): Promise<ApiResponseDto<AdoptionPetDetailResponseDto>> {
+        const result = await this.getAdoptionPetDetailUseCase.execute({ petId, adopterId: userId });
+        return ApiResponseDto.success(result, ADOPTION_RESPONSE_MESSAGE_EXAMPLES.detailRetrieved);
+    }
+}

--- a/src/api/adoption/controller/adoption-list.controller.ts
+++ b/src/api/adoption/controller/adoption-list.controller.ts
@@ -29,6 +29,8 @@ export class AdoptionListController {
     ): Promise<ApiResponseDto<PaginationResponseDto<AdoptionPetResponseDto>>> {
         const result = await this.getAdoptionPetListUseCase.execute({
             petType: query.petType,
+            breederId: query.breederId,
+            excludePetId: query.excludePetId,
             sort: query.sort,
             page: query.page,
             pageSize: query.pageSize,

--- a/src/api/adoption/dto/response/adoption-pet-detail-response.dto.ts
+++ b/src/api/adoption/dto/response/adoption-pet-detail-response.dto.ts
@@ -56,16 +56,28 @@ export class AdoptionPetBreederBlockDto {
     @ApiProperty({ description: '브리더 ID' })
     breederId: string;
 
-    @ApiProperty({ description: '표시용 닉네임', example: '도심속 도마뱀 사장님' })
+    @ApiProperty({
+        description:
+            '표시명. User.nickname 우선, 없으면 Breeder.name(업체명) fallback. 기존 BreederAdminPolicyService.getBreederDisplayName 컨벤션과 동일.',
+        example: '도심속 도마뱀 사장님',
+    })
     displayName: string;
 
-    @ApiProperty({ description: '프로필 이미지 signed URL', required: false })
+    @ApiProperty({
+        description: '프로필 이미지 signed URL (User.profileImageFileName 기반)',
+        required: false,
+    })
     profileImageUrl?: string;
 
-    @ApiProperty({ description: '위치 표기 (가장 구체적인 동/구/시)', example: '독산동', required: false })
+    @ApiProperty({
+        description:
+            '위치 표기. BreederProfile.location.district 우선, city fallback. 상세 주소(address)는 PII 라 공개 응답에서 제외.',
+        example: '독산동',
+        required: false,
+    })
     locationText?: string;
 
-    @ApiProperty({ description: 'Pawpong 활동 점수', example: 80 })
+    @ApiProperty({ description: 'Pawpong 활동 점수 (Breeder.bpm)', example: 80 })
     bpm: number;
 }
 

--- a/src/api/adoption/infrastructure/adoption-breeder-summary-mongoose.adapter.ts
+++ b/src/api/adoption/infrastructure/adoption-breeder-summary-mongoose.adapter.ts
@@ -11,6 +11,13 @@ import {
 /**
  * Breeder 도큐먼트에서 입양 상세 화면 노출용 요약만 추출한다.
  * profileImageUrl 변환(signed URL)은 use-case 에서 AssetUrlPort 로 수행.
+ *
+ * 보안/표시 규칙 (기존 BreederAdminPolicyService.getBreederDisplayName 컨벤션과 동일):
+ * - displayName: User.nickname 우선, Breeder.name(업체명) fallback
+ * - profileImageFileName: User.profileImageFileName (아바타) 만 노출
+ *   BreederProfile.representativePhotos 는 브리더홈/탐색에서 별도 처리
+ * - locationText: district 우선, city fallback
+ *   상세 주소(address)는 PII 라 공개 응답에서 제외
  */
 @Injectable()
 export class AdoptionBreederSummaryMongooseAdapter implements AdoptionBreederSummaryPort {
@@ -21,32 +28,44 @@ export class AdoptionBreederSummaryMongooseAdapter implements AdoptionBreederSum
             return null;
         }
 
-        const breeder: any = await this.model
+        const breeder = await this.model
             .findById(breederId, {
+                name: 1,
                 nickname: 1,
-                profile: 1,
+                profileImageFileName: 1,
+                'profile.location.city': 1,
+                'profile.location.district': 1,
                 bpm: 1,
             })
-            .lean()
+            .lean<{
+                _id: Types.ObjectId;
+                name?: string;
+                nickname?: string;
+                profileImageFileName?: string;
+                profile?: { location?: { city?: string; district?: string } };
+                bpm?: number;
+            }>()
             .exec();
 
         if (!breeder) {
             return null;
         }
 
-        const profile = breeder.profile ?? {};
-        const location = profile.location ?? {};
+        const location = breeder.profile?.location ?? {};
 
-        // 표시용 닉네임: nickname 우선, 없으면 brandName 그 다음 ""
-        const displayName: string = breeder.nickname || profile.brandName || '';
+        // 표시명: User.nickname 우선, Breeder.name(업체명) fallback.
+        // 기존 BreederAdminPolicyService.getBreederDisplayName 컨벤션과 동일.
+        const displayName: string =
+            (breeder.nickname && breeder.nickname.trim()) || (breeder.name && breeder.name.trim()) || '';
 
-        // 위치 표시: address > district > city 순으로 가장 구체적인 값
-        const locationText: string | undefined = location.address || location.district || location.city || undefined;
+        // 위치: district 우선, city fallback. address 는 PII 라 노출하지 않는다.
+        const locationText: string | undefined =
+            (location.district && location.district.trim()) || (location.city && location.city.trim()) || undefined;
 
         return {
             breederId: breeder._id.toString(),
             displayName,
-            profileImageFileName: profile.profileImage || undefined,
+            profileImageFileName: breeder.profileImageFileName || undefined,
             locationText,
             bpm: typeof breeder.bpm === 'number' ? breeder.bpm : 0,
         };

--- a/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
+++ b/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import type { AvailablePetDocument } from '../../../schema/available-pet.schema';
 import {
+    AdoptionPetDetailSnapshot,
     AdoptionPetListQuery,
     AdoptionPetReaderPort,
     AdoptionPetSnapshot,
@@ -13,7 +14,7 @@ import { AdoptionPetRepository } from '../repository/adoption-pet.repository';
 export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
     constructor(private readonly repository: AdoptionPetRepository) {}
 
-    countList(query: Pick<AdoptionPetListQuery, 'petType'>): Promise<number> {
+    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number> {
         return this.repository.countList(query);
     }
 
@@ -30,6 +31,11 @@ export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
     async readById(petId: string): Promise<AdoptionPetSnapshot | null> {
         const item = await this.repository.findById(petId);
         return item ? this.toSnapshot(item as unknown as AvailablePetDocument) : null;
+    }
+
+    async readByIdDetailed(petId: string): Promise<AdoptionPetDetailSnapshot | null> {
+        const item = await this.repository.findActiveById(petId);
+        return item ? this.toDetailSnapshot(item as unknown as AvailablePetDocument) : null;
     }
 
     incrementFavoriteCount(petId: string, delta: number): Promise<void> {
@@ -53,6 +59,24 @@ export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
             viewCount: pet.viewCount ?? 0,
             createdAt: pet.createdAt,
             updatedAt: pet.updatedAt,
+        };
+    }
+
+    private toDetailSnapshot(pet: AvailablePetDocument): AdoptionPetDetailSnapshot {
+        return {
+            ...this.toSnapshot(pet),
+            description: pet.description,
+            // tags 는 별도 필드가 아직 schema 에 없음 — 미래 확장 대비 빈 배열 기본
+            tags: [],
+            representativePhotoIndex: pet.representativePhotoIndex,
+            vaccinationStatus: pet.vaccinationStatus,
+            vaccinationRecords: pet.vaccinationRecords ?? [],
+            vaccinationIncompleteReason: pet.vaccinationIncompleteReason,
+            geneticTestStatus: pet.geneticTestStatus,
+            geneticTestRecords: pet.geneticTestRecords ?? [],
+            geneticTestIncompleteReason: pet.geneticTestIncompleteReason,
+            parentPetSnapshots: pet.parentPetSnapshots ?? [],
+            breedingEnvironment: pet.breedingEnvironment,
         };
     }
 }

--- a/src/api/adoption/repository/adoption-pet.repository.ts
+++ b/src/api/adoption/repository/adoption-pet.repository.ts
@@ -9,34 +9,40 @@ import type { AdoptionPetListQuery, AdoptionPetType } from '../application/ports
 export class AdoptionPetRepository {
     constructor(@InjectModel(AvailablePet.name) private readonly model: Model<AvailablePet>) {}
 
-    private buildBaseFilter(petType?: AdoptionPetType): FilterQuery<AvailablePet> {
+    private buildBaseFilter(input: {
+        petType?: AdoptionPetType;
+        breederId?: string;
+        excludePetId?: string;
+    }): FilterQuery<AvailablePet> {
         const filter: FilterQuery<AvailablePet> = { isActive: true };
-        if (petType) {
-            filter.petType = petType;
+        if (input.petType) {
+            filter.petType = input.petType;
+        }
+        if (input.breederId && Types.ObjectId.isValid(input.breederId)) {
+            filter.breederId = new Types.ObjectId(input.breederId);
+        }
+        if (input.excludePetId && Types.ObjectId.isValid(input.excludePetId)) {
+            filter._id = { $ne: new Types.ObjectId(input.excludePetId) };
         }
         return filter;
     }
 
-    countList(query: Pick<AdoptionPetListQuery, 'petType'>): Promise<number> {
-        return this.model.countDocuments(this.buildBaseFilter(query.petType)).exec();
+    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number> {
+        return this.model.countDocuments(this.buildBaseFilter(query)).exec();
     }
 
     findList(query: AdoptionPetListQuery): Promise<AvailablePet[]> {
-        const filter = this.buildBaseFilter(query.petType);
+        const filter = this.buildBaseFilter(query);
         const sort: Record<string, 1 | -1> =
             query.sort === 'popular' ? { favoriteCount: -1, createdAt: -1 } : { createdAt: -1 };
         return this.model.find(filter).sort(sort).skip(query.skip).limit(query.limit).exec();
     }
 
     findPopular(petType: AdoptionPetType | undefined, limit: number): Promise<AvailablePet[]> {
-        const filter = this.buildBaseFilter(petType);
+        const filter = this.buildBaseFilter({ petType });
         // 인기 동물은 입양 가능 상태만 노출
         filter.status = 'available';
-        return this.model
-            .find(filter)
-            .sort({ favoriteCount: -1, viewCount: -1, createdAt: -1 })
-            .limit(limit)
-            .exec();
+        return this.model.find(filter).sort({ favoriteCount: -1, viewCount: -1, createdAt: -1 }).limit(limit).exec();
     }
 
     findById(petId: string): Promise<AvailablePet | null> {
@@ -46,10 +52,38 @@ export class AdoptionPetRepository {
         return this.model.findById(petId).exec();
     }
 
+    /**
+     * isActive=false 항목은 조회 결과에서 제외한다 (입양 상세 진입 차단).
+     */
+    findActiveById(petId: string): Promise<AvailablePet | null> {
+        if (!Types.ObjectId.isValid(petId)) {
+            return Promise.resolve(null);
+        }
+        return this.model.findOne({ _id: new Types.ObjectId(petId), isActive: true }).exec();
+    }
+
     async incrementFavoriteCount(petId: string, delta: number): Promise<void> {
         if (!Types.ObjectId.isValid(petId)) {
             return;
         }
         await this.model.updateOne({ _id: new Types.ObjectId(petId) }, { $inc: { favoriteCount: delta } }).exec();
+    }
+
+    /**
+     * 상세 진입 viewCount 원자 증가. isActive=true 인 도큐먼트만 갱신하며, 갱신 후의 viewCount 를 반환한다.
+     * 항목이 없거나 비활성이면 null 반환.
+     */
+    async incrementViewCount(petId: string): Promise<number | null> {
+        if (!Types.ObjectId.isValid(petId)) {
+            return null;
+        }
+        const updated = await this.model
+            .findOneAndUpdate(
+                { _id: new Types.ObjectId(petId), isActive: true },
+                { $inc: { viewCount: 1 } },
+                { new: true, projection: { viewCount: 1 } },
+            )
+            .exec();
+        return updated?.viewCount ?? null;
     }
 }

--- a/src/api/adoption/swagger/index.ts
+++ b/src/api/adoption/swagger/index.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiParam } from '@nestjs/swagger';
+import { ApiParam, ApiQuery } from '@nestjs/swagger';
 
 import {
     ApiController,
@@ -10,6 +10,7 @@ import {
 import { PaginationResponseDto } from '../../../common/dto/pagination/pagination-response.dto';
 import { ADOPTION_RESPONSE_MESSAGE_EXAMPLES } from '../constants/adoption-response-messages';
 import { AdoptedPetCardResponseDto } from '../dto/response/adopted-pet-card.dto';
+import { AdoptionPetDetailResponseDto } from '../dto/response/adoption-pet-detail-response.dto';
 import { AdoptionFavoriteResponseDto, AdoptionPetResponseDto } from '../dto/response/adoption-pet-response.dto';
 
 const PET_NOT_FOUND_RESPONSE = {
@@ -32,9 +33,13 @@ export function ApiGetAdoptionListEndpoint() {
             summary: '입양 가능 동물 목록 조회',
             description: `
                 입양 페이지의 "전체 입양 소식" 목록을 페이지네이션으로 반환합니다.
+                카테고리탭(Figma 6:131) — petType 필터로 동물 종류별 노출.
+                상세 화면(Figma 39:1240) — breederId + excludePetId 조합으로 "브리더의 다른 분양 동물" 영역 조회.
 
                 ## 주요 기능
                 - petType 필터 (강아지/고양이/도마뱀)
+                - breederId 필터 (특정 브리더의 분양 동물만)
+                - excludePetId (특정 펫을 결과에서 제외 — 상세 화면 자기 자신 제외용)
                 - 정렬: 최신순(latest) / 인기순(popular)
                 - 인증 사용자는 카드별 isFavorited 가 채워집니다
             `,
@@ -45,6 +50,8 @@ export function ApiGetAdoptionListEndpoint() {
             successDescription: '입양 동물 목록 조회 성공',
             successMessageExample: ADOPTION_RESPONSE_MESSAGE_EXAMPLES.listRetrieved,
         }),
+        ApiQuery({ name: 'breederId', required: false, type: String, description: '특정 브리더 필터 (ObjectId)' }),
+        ApiQuery({ name: 'excludePetId', required: false, type: String, description: '결과에서 제외할 펫 ID' }),
     );
 }
 
@@ -67,11 +74,47 @@ export function ApiGetPopularAdoptionEndpoint() {
     );
 }
 
+export function ApiGetAdoptionDetailEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '입양 동물 상세 조회 (Figma 39:1240)',
+            description: `
+                입양 상세 화면에 필요한 모든 정보를 한 번에 반환합니다.
+
+                ## 동작
+                - 상세 진입 시 viewCount 가 +1 증가합니다 (isActive=true 도큐먼트만 대상).
+                - 비활성 또는 미존재 펫은 400 으로 응답합니다.
+
+                ## 응답 구성
+                - 카드 필드 (이름/품종/가격/상태/사진/카운트 등)
+                - 건강 정보 (예방 접종 기록, 유전병 검사 기록 — 미완료시 사유)
+                - 부모 정보 스냅샷 (관계/품종/이름/생년/사진)
+                - 사육 환경 (설명 + 사진)
+                - 브리더 요약 (닉네임 우선 / 프로필 / 위치 동·구 / BPM)
+                - 인증 사용자는 isFavorited 채워집니다.
+
+                ## 브리더 요약 정책 (BreederAdminPolicyService.getBreederDisplayName 와 동일 컨벤션)
+                - displayName: User.nickname 우선, 없으면 Breeder.name(업체명) fallback
+                - profileImageUrl: User.profileImageFileName (아바타) 의 signed URL
+                - locationText: BreederProfile.location.district 우선, city fallback — 상세 주소(address)는 PII 라 노출하지 않음
+            `,
+            responseType: AdoptionPetDetailResponseDto,
+            isPublic: true,
+            supportsOptionalAuth: true,
+            successDescription: '입양 동물 상세 조회 성공',
+            successMessageExample: ADOPTION_RESPONSE_MESSAGE_EXAMPLES.detailRetrieved,
+            errorResponses: [PET_NOT_FOUND_RESPONSE],
+        }),
+        ApiParam({ name: 'petId', description: '동물 ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
 export function ApiAddAdoptionFavoriteEndpoint() {
     return applyDecorators(
         ApiEndpoint({
             summary: '동물 관심 등록',
-            description: '입양 가능 동물을 입양자 즐겨찾기에 추가합니다. 이미 등록된 경우에도 200 으로 처리됩니다 (idempotent).',
+            description:
+                '입양 가능 동물을 입양자 즐겨찾기에 추가합니다. 이미 등록된 경우에도 200 으로 처리됩니다 (idempotent).',
             responseType: AdoptionFavoriteResponseDto,
             successDescription: '관심 등록 성공',
             successMessageExample: ADOPTION_RESPONSE_MESSAGE_EXAMPLES.favoriteAdded,
@@ -85,7 +128,8 @@ export function ApiRemoveAdoptionFavoriteEndpoint() {
     return applyDecorators(
         ApiEndpoint({
             summary: '동물 관심 해제',
-            description: '입양자 즐겨찾기에서 동물을 제거합니다. 등록되어 있지 않아도 200 으로 처리됩니다 (idempotent).',
+            description:
+                '입양자 즐겨찾기에서 동물을 제거합니다. 등록되어 있지 않아도 200 으로 처리됩니다 (idempotent).',
             responseType: AdoptionFavoriteResponseDto,
             successDescription: '관심 해제 성공',
             successMessageExample: ADOPTION_RESPONSE_MESSAGE_EXAMPLES.favoriteRemoved,


### PR DESCRIPTION
## Summary

- v2 입양 상세 (`GET /v2/adoption/:petId`) — Figma 39:1240, viewCount 원자 증가 + 건강/부모/사육환경/브리더 요약 한 번에
- v2 입양 리스트 `breederId / excludePetId` 파라미터 — Figma 39:1240 "브리더의 다른 분양 동물" + 6:131 카테고리탭
- 브리더 요약 정책 정렬 (Codex 리뷰 2회 반영): nickname-first / district 제한 / PII 제외

## Why a "fix" commit on dev

dev 머지에서 detail use-case · writer adapter · breeder summary adapter 신규 파일은 들어왔지만 의존하는 port / type / repository 갱신이 누락돼 typecheck 가 깨져 있었음. 본 PR 이 컴파일 복원 + Codex 두 라운드 피드백을 한 번에 정리한다.

## API 변경

| 변경 | 라우트 |
|---|---|
| 신규 | `GET /v2/adoption/:petId` |
| 확장 | `GET /v2/adoption?breederId=&excludePetId=` |

## 브리더 요약 정책 (`BreederAdminPolicyService.getBreederDisplayName` 컨벤션 정렬)

- `displayName`: User.nickname 우선, Breeder.name(업체명) fallback
- `profileImageUrl`: User.profileImageFileName(아바타) signed URL
- `locationText`: district 우선, city fallback — **상세 주소(address)는 PII 라 공개 응답에서 제외**

## Test plan

- [x] `tsc --noEmit` 통과
- [ ] e2e: 입양 상세 진입 시 viewCount +1 / isActive=false 펫은 400
- [ ] e2e: 비로그인 / 로그인 입양자 — isFavorited 채움 여부
- [ ] 응답 페이로드에 `breeder.location.address` 가 절대 노출되지 않는지 검증