### PR TITLE
feat(community): v2 list 에 authorId='me' 필터 (Figma 278:170 마이홈 게시글 탭)

### DIFF
--- a/src/api/community/application/types/community-post.type.ts
+++ b/src/api/community/application/types/community-post.type.ts
@@ -40,6 +40,11 @@ export interface CommunityPostCommentSnapshot {
 export interface CommunityPostListQuery {
     petType?: CommunityPetType;
     category?: string;
+    /**
+     * 작성자 ID 필터 — 마이홈 게시글 탭 (Figma 278:170) 등.
+     * 컨트롤러에서 'me' 별칭을 인증 사용자 id 로 치환한 뒤 전달한다.
+     */
+    authorId?: string;
     sort: CommunityPostSort;
     skip: number;
     limit: number;

--- a/src/api/community/application/use-cases/get-community-post-list.use-case.ts
+++ b/src/api/community/application/use-cases/get-community-post-list.use-case.ts
@@ -23,6 +23,7 @@ export class GetCommunityPostListUseCase {
     async execute(input: {
         petType?: CommunityPetType;
         category?: string;
+        authorId?: string;
         sort?: CommunityPostSort;
         page?: number;
         pageSize?: number;
@@ -34,6 +35,7 @@ export class GetCommunityPostListUseCase {
         const { snapshots, totalItems } = await this.reader.listPosts({
             petType: input.petType,
             category: input.category,
+            authorId: input.authorId,
             sort,
             skip: (page - 1) * pageSize,
             limit: pageSize,

--- a/src/api/community/controller/community-post-list.controller.ts
+++ b/src/api/community/controller/community-post-list.controller.ts
@@ -1,5 +1,6 @@
-import { Get, Query } from '@nestjs/common';
+import { Get, Query, UnauthorizedException } from '@nestjs/common';
 
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { PaginationResponseDto } from '../../../common/dto/pagination/pagination-response.dto';
 
@@ -18,10 +19,14 @@ export class CommunityPostListController {
     @ApiGetCommunityPostListEndpoint()
     async list(
         @Query() query: CommunityPostListQueryDto,
+        @CurrentUser('userId') userId?: string,
     ): Promise<ApiResponseDto<PaginationResponseDto<CommunityPostCardResponseDto>>> {
+        const resolvedAuthorId = this.resolveAuthorId(query.authorId, userId);
+
         const result = await this.useCase.execute({
             petType: query.petType,
             category: query.category,
+            authorId: resolvedAuthorId,
             sort: query.sort,
             page: query.page,
             pageSize: query.pageSize,
@@ -30,5 +35,23 @@ export class CommunityPostListController {
             PaginationResponseDto.fromPageResult(result),
             COMMUNITY_RESPONSE_MESSAGES.listRetrieved,
         );
+    }
+
+    /**
+     * authorId='me' 별칭은 인증된 본인 id 로 치환한다.
+     * 비로그인 사용자가 'me' 를 지정하면 401 — 공개 list 자체는 OptionalAuth 라 토큰이 없어도
+     * 다른 사용자 게시글은 볼 수 있지만, 본인 글 필터는 인증 전제이므로 명시적으로 차단.
+     */
+    private resolveAuthorId(authorId: string | undefined, userId?: string): string | undefined {
+        if (!authorId) {
+            return undefined;
+        }
+        if (authorId === 'me') {
+            if (!userId) {
+                throw new UnauthorizedException('authorId="me" 사용은 인증 토큰이 필요합니다.');
+            }
+            return userId;
+        }
+        return authorId;
     }
 }

--- a/src/api/community/dto/request/community-post-list-query.dto.ts
+++ b/src/api/community/dto/request/community-post-list-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Matches, Max, MaxLength, Min } from 'class-validator';
 
 export class CommunityPostListQueryDto {
     @ApiPropertyOptional({ description: '동물 종류 필터', enum: ['dog', 'cat', 'reptile'] })
@@ -13,6 +13,16 @@ export class CommunityPostListQueryDto {
     @IsString()
     @MaxLength(50)
     category?: string;
+
+    @ApiPropertyOptional({
+        description:
+            '작성자 필터. ObjectId 또는 별칭 "me" (마이홈 게시글 탭, Figma 278:170). "me" 사용 시 인증 토큰 필요.',
+        example: 'me',
+    })
+    @IsOptional()
+    @IsString()
+    @Matches(/^(me|[0-9a-fA-F]{24})$/, { message: 'authorId 는 "me" 또는 24자 ObjectId 여야 합니다.' })
+    authorId?: string;
 
     @ApiPropertyOptional({ description: '정렬', enum: ['latest', 'popular'], example: 'latest' })
     @IsOptional()

--- a/src/api/community/repository/community.repository.ts
+++ b/src/api/community/repository/community.repository.ts
@@ -38,6 +38,9 @@ export class CommunityRepository {
         const filter: FilterQuery<CommunityPost> = { isActive: true };
         if (query.petType) filter.petType = query.petType;
         if (query.category && query.category.trim().length > 0) filter.category = query.category.trim();
+        if (query.authorId && Types.ObjectId.isValid(query.authorId)) {
+            filter.authorId = new Types.ObjectId(query.authorId);
+        }
 
         const sort: Record<string, 1 | -1> =
             query.sort === 'popular' ? { likeCount: -1, createdAt: -1 } : { createdAt: -1 };

--- a/src/api/community/swagger/index.ts
+++ b/src/api/community/swagger/index.ts
@@ -34,6 +34,7 @@ export function ApiGetCommunityPostListEndpoint() {
                 ## 필터 / 정렬
                 - petType (선택): dog / cat / reptile
                 - category (선택): 자유 텍스트 정확 일치 (예: "레오파드")
+                - authorId (선택): ObjectId 또는 "me" — "me" 는 인증 토큰 필요 (마이홈 게시글 탭, Figma 278:170)
                 - sort: latest(기본) / popular(likeCount desc)
 
                 ## 응답


### PR DESCRIPTION
## Summary

마이홈(Figma 278:170)의 \"게시글\" 탭에서 본인 작성 글만 노출하기 위한 \`authorId\` 필터 추가.

- \`GET /v2/community/posts?authorId=me\` — 컨트롤러에서 \`CurrentUser\`의 userId 로 치환
- \`GET /v2/community/posts?authorId=<ObjectId>\` — 특정 사용자의 글 (확장성)
- 비로그인 + \`me\` = 401
- 잘못된 입력 (ObjectId/me 둘 다 아님) = 400 (DTO 정규식)

기존 list 와 합쳐서 처리 — 별도 \`me/posts\` endpoint 보다 client/server 모두 단순.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] e2e: \`?authorId=me\` 인증 토큰 있을 때 → 본인 글만
- [ ] e2e: \`?authorId=me\` 비로그인 → 401
- [ ] e2e: \`?authorId=<다른사람Id>\` → 그 사람의 글만
- [ ] e2e: \`?authorId=invalid\` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)