### PR TITLE
feat(profile): v2 PATCH /v2/profile/me — bio 편집 (Figma 278:170)

### DIFF
--- a/src/api/profile/application/ports/profile-writer.port.ts
+++ b/src/api/profile/application/ports/profile-writer.port.ts
@@ -1,0 +1,19 @@
+export type ProfileUpdatableRole = 'adopter' | 'breeder';
+
+export type UpdateMyProfileCommand = {
+    /**
+     * 한 줄 소개. trim 결과 길이가 0~200 이어야 한다.
+     * 빈 문자열 ("") 은 명시적으로 한 줄 소개를 비우는 의도 — null/undefined 와 의미 다름.
+     */
+    bio?: string;
+};
+
+export const PROFILE_WRITER_PORT = Symbol('PROFILE_WRITER_PORT');
+
+export interface ProfileWriterPort {
+    /**
+     * 마이홈 프로필 편집. role 에 따라 Adopter/Breeder 도큐먼트에 적용.
+     * 사용자/도큐먼트가 없으면 false. 변경 없으면 true 반환 (idempotent).
+     */
+    updateMyProfile(userId: string, role: ProfileUpdatableRole, command: UpdateMyProfileCommand): Promise<boolean>;
+}

--- a/src/api/profile/application/use-cases/update-my-profile.use-case.ts
+++ b/src/api/profile/application/use-cases/update-my-profile.use-case.ts
@@ -1,0 +1,48 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { GetMyProfileUseCase } from './get-my-profile.use-case';
+import type { MyProfileResponseDto } from '../../dto/response/my-profile-response.dto';
+import {
+    PROFILE_WRITER_PORT,
+    type ProfileUpdatableRole,
+    type ProfileWriterPort,
+    type UpdateMyProfileCommand,
+} from '../ports/profile-writer.port';
+
+const BIO_MAX_LENGTH = 200;
+
+@Injectable()
+export class UpdateMyProfileUseCase {
+    constructor(
+        @Inject(PROFILE_WRITER_PORT)
+        private readonly writer: ProfileWriterPort,
+        private readonly getMyProfileUseCase: GetMyProfileUseCase,
+    ) {}
+
+    async execute(
+        userId: string,
+        role: ProfileUpdatableRole,
+        command: UpdateMyProfileCommand,
+    ): Promise<MyProfileResponseDto> {
+        const sanitized = this.sanitize(command);
+
+        const updated = await this.writer.updateMyProfile(userId, role, sanitized);
+        if (!updated) {
+            throw new BadRequestException('프로필 정보를 찾을 수 없습니다.');
+        }
+
+        return this.getMyProfileUseCase.execute(userId, role);
+    }
+
+    private sanitize(command: UpdateMyProfileCommand): UpdateMyProfileCommand {
+        const sanitized: UpdateMyProfileCommand = {};
+        if (command.bio !== undefined) {
+            const trimmed = command.bio.trim();
+            if (trimmed.length > BIO_MAX_LENGTH) {
+                throw new BadRequestException(`한 줄 소개는 ${BIO_MAX_LENGTH}자 이내여야 합니다.`);
+            }
+            sanitized.bio = trimmed;
+        }
+        return sanitized;
+    }
+}

--- a/src/api/profile/constants/profile-response-messages.ts
+++ b/src/api/profile/constants/profile-response-messages.ts
@@ -1,5 +1,6 @@
 export const PROFILE_RESPONSE_MESSAGES = {
     myRetrieved: '내 프로필 조회 성공',
+    myUpdated: '내 프로필 수정 성공',
     adopterRetrieved: '입양자 프로필 조회 성공',
     breederRetrieved: '브리더 프로필 조회 성공',
     favoriteBreedersRetrieved: '즐겨찾는 브리더 목록 조회 성공',

--- a/src/api/profile/controller/profile-me.controller.ts
+++ b/src/api/profile/controller/profile-me.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Get, Query } from '@nestjs/common';
+import { BadRequestException, Body, Get, Patch, Query } from '@nestjs/common';
 
 import { CurrentUser } from '../../../common/decorator/current-user.decorator';
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
@@ -6,22 +6,27 @@ import { PaginationResponseDto } from '../../../common/dto/pagination/pagination
 
 import { GetMyFavoriteBreedersUseCase } from '../application/use-cases/get-my-favorite-breeders.use-case';
 import { GetMyProfileUseCase } from '../application/use-cases/get-my-profile.use-case';
+import { UpdateMyProfileUseCase } from '../application/use-cases/update-my-profile.use-case';
 import { PROFILE_RESPONSE_MESSAGES } from '../constants/profile-response-messages';
 import {
     ProfileFavoritesController,
     ProfileMeController as ProfileMeControllerDecorator,
 } from '../decorator/profile-protected-controller.decorator';
 import { FavoriteBreedersQueryDto } from '../dto/request/favorite-breeders-query.dto';
+import { UpdateMyProfileRequestDto } from '../dto/request/update-my-profile-request.dto';
 import { FavoriteBreederCardResponseDto } from '../dto/response/favorite-breeder-card.dto';
 import { MyProfileResponseDto } from '../dto/response/my-profile-response.dto';
-import { ApiGetMyFavoriteBreedersEndpoint, ApiGetMyProfileEndpoint } from '../swagger';
+import { ApiGetMyFavoriteBreedersEndpoint, ApiGetMyProfileEndpoint, ApiUpdateMyProfileEndpoint } from '../swagger';
 
 /**
- * GET /v2/profile/me (인증 필수, role 무관)
+ * GET / PATCH /v2/profile/me (인증 필수, role 무관)
  */
 @ProfileMeControllerDecorator()
 export class ProfileMeController {
-    constructor(private readonly getMyProfileUseCase: GetMyProfileUseCase) {}
+    constructor(
+        private readonly getMyProfileUseCase: GetMyProfileUseCase,
+        private readonly updateMyProfileUseCase: UpdateMyProfileUseCase,
+    ) {}
 
     @Get('me')
     @ApiGetMyProfileEndpoint()
@@ -34,6 +39,20 @@ export class ProfileMeController {
         }
         const result = await this.getMyProfileUseCase.execute(userId, role);
         return ApiResponseDto.success(result, PROFILE_RESPONSE_MESSAGES.myRetrieved);
+    }
+
+    @Patch('me')
+    @ApiUpdateMyProfileEndpoint()
+    async updateMe(
+        @CurrentUser('userId') userId: string,
+        @CurrentUser('role') role: string,
+        @Body() body: UpdateMyProfileRequestDto,
+    ): Promise<ApiResponseDto<MyProfileResponseDto>> {
+        if (role !== 'adopter' && role !== 'breeder') {
+            throw new BadRequestException('지원하지 않는 사용자 역할입니다.');
+        }
+        const result = await this.updateMyProfileUseCase.execute(userId, role, { bio: body.bio });
+        return ApiResponseDto.success(result, PROFILE_RESPONSE_MESSAGES.myUpdated);
     }
 }
 

--- a/src/api/profile/dto/request/update-my-profile-request.dto.ts
+++ b/src/api/profile/dto/request/update-my-profile-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateMyProfileRequestDto {
+    @ApiPropertyOptional({
+        description: '한 줄 소개. trim 후 200자 이내. 빈 문자열은 한 줄 소개 비움을 의미한다.',
+        example: '도심속 도마뱀 사장님',
+        maxLength: 200,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    bio?: string;
+}

--- a/src/api/profile/infrastructure/profile-writer-mongoose.adapter.ts
+++ b/src/api/profile/infrastructure/profile-writer-mongoose.adapter.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+    ProfileUpdatableRole,
+    ProfileWriterPort,
+    UpdateMyProfileCommand,
+} from '../application/ports/profile-writer.port';
+import { ProfileRepository } from '../repository/profile.repository';
+
+@Injectable()
+export class ProfileWriterMongooseAdapter implements ProfileWriterPort {
+    constructor(private readonly repository: ProfileRepository) {}
+
+    async updateMyProfile(
+        userId: string,
+        role: ProfileUpdatableRole,
+        command: UpdateMyProfileCommand,
+    ): Promise<boolean> {
+        if (role === 'adopter') {
+            return this.repository.updateAdopterProfile(userId, command);
+        }
+        return this.repository.updateBreederProfile(userId, command);
+    }
+}

--- a/src/api/profile/profile.module-definition.ts
+++ b/src/api/profile/profile.module-definition.ts
@@ -7,13 +7,16 @@ import { Breeder, BreederSchema } from '../../schema/breeder.schema';
 
 import { PROFILE_ASSET_URL_PORT } from './application/ports/profile-asset-url.port';
 import { PROFILE_READER_PORT } from './application/ports/profile-reader.port';
+import { PROFILE_WRITER_PORT } from './application/ports/profile-writer.port';
 import { GetAdopterProfileUseCase } from './application/use-cases/get-adopter-profile.use-case';
 import { GetBreederProfileUseCase } from './application/use-cases/get-breeder-profile.use-case';
 import { GetMyFavoriteBreedersUseCase } from './application/use-cases/get-my-favorite-breeders.use-case';
 import { GetMyProfileUseCase } from './application/use-cases/get-my-profile.use-case';
+import { UpdateMyProfileUseCase } from './application/use-cases/update-my-profile.use-case';
 import { ProfileMapperService } from './domain/services/profile-mapper.service';
 import { ProfileAssetUrlStorageAdapter } from './infrastructure/profile-asset-url-storage.adapter';
 import { ProfileReaderMongooseAdapter } from './infrastructure/profile-reader-mongoose.adapter';
+import { ProfileWriterMongooseAdapter } from './infrastructure/profile-writer-mongoose.adapter';
 import {
     ProfileFavoriteBreedersController,
     ProfileMeController,
@@ -37,6 +40,7 @@ export const PROFILE_MODULE_CONTROLLERS = [
 
 const USE_CASE_PROVIDERS = [
     GetMyProfileUseCase,
+    UpdateMyProfileUseCase,
     GetAdopterProfileUseCase,
     GetBreederProfileUseCase,
     GetMyFavoriteBreedersUseCase,
@@ -47,11 +51,13 @@ const DOMAIN_PROVIDERS = [ProfileMapperService];
 const INFRASTRUCTURE_PROVIDERS = [
     ProfileRepository,
     ProfileReaderMongooseAdapter,
+    ProfileWriterMongooseAdapter,
     ProfileAssetUrlStorageAdapter,
 ];
 
 const PORT_BINDINGS = [
     { provide: PROFILE_READER_PORT, useExisting: ProfileReaderMongooseAdapter },
+    { provide: PROFILE_WRITER_PORT, useExisting: ProfileWriterMongooseAdapter },
     { provide: PROFILE_ASSET_URL_PORT, useExisting: ProfileAssetUrlStorageAdapter },
 ];
 

--- a/src/api/profile/repository/profile.repository.ts
+++ b/src/api/profile/repository/profile.repository.ts
@@ -70,4 +70,43 @@ export class ProfileRepository {
         if (!adopter?.favoriteBreederList) return false;
         return adopter.favoriteBreederList.some((entry) => entry.favoriteBreederId === breederId);
     }
+
+    /**
+     * 입양자 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     * 변경 항목이 없거나 동일 값이라도 true 로 처리 — 호출측 idempotent.
+     */
+    async updateAdopterProfile(userId: string, patch: { bio?: string }): Promise<boolean> {
+        if (!Types.ObjectId.isValid(userId)) return false;
+        const $set: Record<string, unknown> = {};
+        if (patch.bio !== undefined) $set.bio = patch.bio;
+
+        if (Object.keys($set).length === 0) {
+            const exists = await this.adopterModel.exists({ _id: new Types.ObjectId(userId) });
+            return Boolean(exists);
+        }
+
+        const result = await this.adopterModel
+            .updateOne({ _id: new Types.ObjectId(userId) }, { $set })
+            .exec();
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * 브리더 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     */
+    async updateBreederProfile(breederId: string, patch: { bio?: string }): Promise<boolean> {
+        if (!Types.ObjectId.isValid(breederId)) return false;
+        const $set: Record<string, unknown> = {};
+        if (patch.bio !== undefined) $set.bio = patch.bio;
+
+        if (Object.keys($set).length === 0) {
+            const exists = await this.breederModel.exists({ _id: new Types.ObjectId(breederId) });
+            return Boolean(exists);
+        }
+
+        const result = await this.breederModel
+            .updateOne({ _id: new Types.ObjectId(breederId) }, { $set })
+            .exec();
+        return result.matchedCount > 0;
+    }
 }

--- a/src/api/profile/swagger/index.ts
+++ b/src/api/profile/swagger/index.ts
@@ -41,6 +41,27 @@ export function ApiGetMyProfileEndpoint() {
     );
 }
 
+export function ApiUpdateMyProfileEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '내 프로필 수정 (마이홈, Figma 278:170 "프로필 편집")',
+            description: `
+                현재 인증된 사용자의 프로필을 부분 수정한다. role 에 따라 Adopter/Breeder 도큐먼트에 적용.
+
+                ## 지원 필드 (이번 슬라이스)
+                - bio (선택): 한 줄 소개. trim 후 200자 이내. 빈 문자열은 한 줄 소개 비움 의도.
+
+                ## 응답
+                - 수정 후 GetMyProfile 와 동일한 응답 (계약 일관성)
+            `,
+            responseType: MyProfileResponseDto,
+            successDescription: '내 프로필 수정 성공',
+            successMessageExample: PROFILE_RESPONSE_MESSAGES.myUpdated,
+            errorResponses: [NOT_FOUND_RESPONSE],
+        }),
+    );
+}
+
 export function ApiGetAdopterProfileEndpoint() {
     return applyDecorators(
         ApiEndpoint({


### PR DESCRIPTION
## Summary

마이홈(Figma 278:170) 헤더의 \"프로필 편집\" 버튼이 호출하는 endpoint.

- \`PATCH /v2/profile/me\` 신규
- 본 슬라이스는 \`bio\` (한 줄 소개) 만 지원 — 200자 이내, trim 후 빈 문자열 허용 (한 줄 소개 비움 의도)
- role 에 따라 Adopter / Breeder 도큐먼트에 적용

## Hex 구조

| 계층 | 신규 |
|---|---|
| port | \`ProfileWriterPort\` (read/write 분리) |
| use-case | \`UpdateMyProfileUseCase\` (trim + 길이 검증, role 분기) |
| adapter | \`ProfileWriterMongooseAdapter\` |
| repository | \`updateAdopterProfile\` / \`updateBreederProfile\` |
| DTO | \`UpdateMyProfileRequestDto\` (bio?: string) |
| swagger | \`ApiUpdateMyProfileEndpoint\` |

응답은 \`GET /v2/profile/me\` 와 동일한 \`MyProfileResponseDto\` — 클라이언트가 갱신 결과를 그대로 반영 가능.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] e2e: 입양자가 \`{ bio: '안녕' }\` PATCH → adopter.bio 갱신, 응답 \`MyProfileResponseDto\` 정상
- [ ] e2e: 브리더가 \`{ bio: '안녕' }\` PATCH → breeder.bio 갱신
- [ ] e2e: 201자 bio → 400
- [ ] e2e: 비로그인 → 401 (Protected controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)