### PR TITLE
feat(profile): v2 PATCH /v2/profile/me — 사업장 위치 편집 (Figma 290:668 브리더 마이홈)

### DIFF
--- a/src/api/profile/application/ports/profile-writer.port.ts
+++ b/src/api/profile/application/ports/profile-writer.port.ts
@@ -1,0 +1,19 @@
+export type ProfileUpdatableRole = 'adopter' | 'breeder';
+
+export type UpdateMyProfileCommand = {
+    /**
+     * 한 줄 소개. trim 결과 길이가 0~200 이어야 한다.
+     * 빈 문자열 ("") 은 명시적으로 한 줄 소개를 비우는 의도 — null/undefined 와 의미 다름.
+     */
+    bio?: string;
+};
+
+export const PROFILE_WRITER_PORT = Symbol('PROFILE_WRITER_PORT');
+
+export interface ProfileWriterPort {
+    /**
+     * 마이홈 프로필 편집. role 에 따라 Adopter/Breeder 도큐먼트에 적용.
+     * 사용자/도큐먼트가 없으면 false. 변경 없으면 true 반환 (idempotent).
+     */
+    updateMyProfile(userId: string, role: ProfileUpdatableRole, command: UpdateMyProfileCommand): Promise<boolean>;
+}

--- a/src/api/profile/application/ports/profile-writer.port.ts
+++ b/src/api/profile/application/ports/profile-writer.port.ts
@@ -1,11 +1,32 @@
 export type ProfileUpdatableRole = 'adopter' | 'breeder';
 
+/**
+ * 사업장 위치 — Breeder 전용 (Figma 290:668 마이홈 "사업장 위치를 작성해주세요" CTA).
+ * Adopter 가 location 을 보내면 use-case 가 400 으로 거부한다 (Adopter 스키마에 해당 필드 없음).
+ *
+ * 각 부분 필드:
+ * - city / district: 시·구 (각 ≤ 50자)
+ * - address: 상세 주소 (≤ 200자) — 입력은 받지만 공개 응답에는 PII 라 노출하지 않는다 (브리더 본인 응답에는 노출 가능).
+ *
+ * 빈 문자열 ("") 은 명시적으로 비우는 의도 — null/undefined 와 의미 다름.
+ */
+export type UpdateMyProfileLocation = {
+    city?: string;
+    district?: string;
+    address?: string;
+};
+
 export type UpdateMyProfileCommand = {
     /**
      * 한 줄 소개. trim 결과 길이가 0~200 이어야 한다.
      * 빈 문자열 ("") 은 명시적으로 한 줄 소개를 비우는 의도 — null/undefined 와 의미 다름.
      */
     bio?: string;
+
+    /**
+     * 사업장 위치 — Breeder 만 지원. Adopter 가 보내면 거부된다.
+     */
+    location?: UpdateMyProfileLocation;
 };
 
 export const PROFILE_WRITER_PORT = Symbol('PROFILE_WRITER_PORT');

--- a/src/api/profile/application/use-cases/update-my-profile.use-case.ts
+++ b/src/api/profile/application/use-cases/update-my-profile.use-case.ts
@@ -1,0 +1,48 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { GetMyProfileUseCase } from './get-my-profile.use-case';
+import type { MyProfileResponseDto } from '../../dto/response/my-profile-response.dto';
+import {
+    PROFILE_WRITER_PORT,
+    type ProfileUpdatableRole,
+    type ProfileWriterPort,
+    type UpdateMyProfileCommand,
+} from '../ports/profile-writer.port';
+
+const BIO_MAX_LENGTH = 200;
+
+@Injectable()
+export class UpdateMyProfileUseCase {
+    constructor(
+        @Inject(PROFILE_WRITER_PORT)
+        private readonly writer: ProfileWriterPort,
+        private readonly getMyProfileUseCase: GetMyProfileUseCase,
+    ) {}
+
+    async execute(
+        userId: string,
+        role: ProfileUpdatableRole,
+        command: UpdateMyProfileCommand,
+    ): Promise<MyProfileResponseDto> {
+        const sanitized = this.sanitize(command);
+
+        const updated = await this.writer.updateMyProfile(userId, role, sanitized);
+        if (!updated) {
+            throw new BadRequestException('프로필 정보를 찾을 수 없습니다.');
+        }
+
+        return this.getMyProfileUseCase.execute(userId, role);
+    }
+
+    private sanitize(command: UpdateMyProfileCommand): UpdateMyProfileCommand {
+        const sanitized: UpdateMyProfileCommand = {};
+        if (command.bio !== undefined) {
+            const trimmed = command.bio.trim();
+            if (trimmed.length > BIO_MAX_LENGTH) {
+                throw new BadRequestException(`한 줄 소개는 ${BIO_MAX_LENGTH}자 이내여야 합니다.`);
+            }
+            sanitized.bio = trimmed;
+        }
+        return sanitized;
+    }
+}

--- a/src/api/profile/application/use-cases/update-my-profile.use-case.ts
+++ b/src/api/profile/application/use-cases/update-my-profile.use-case.ts
@@ -7,9 +7,13 @@ import {
     type ProfileUpdatableRole,
     type ProfileWriterPort,
     type UpdateMyProfileCommand,
+    type UpdateMyProfileLocation,
 } from '../ports/profile-writer.port';
 
 const BIO_MAX_LENGTH = 200;
+const LOCATION_CITY_MAX = 50;
+const LOCATION_DISTRICT_MAX = 50;
+const LOCATION_ADDRESS_MAX = 200;
 
 @Injectable()
 export class UpdateMyProfileUseCase {
@@ -24,7 +28,7 @@ export class UpdateMyProfileUseCase {
         role: ProfileUpdatableRole,
         command: UpdateMyProfileCommand,
     ): Promise<MyProfileResponseDto> {
-        const sanitized = this.sanitize(command);
+        const sanitized = this.sanitize(role, command);
 
         const updated = await this.writer.updateMyProfile(userId, role, sanitized);
         if (!updated) {
@@ -34,8 +38,9 @@ export class UpdateMyProfileUseCase {
         return this.getMyProfileUseCase.execute(userId, role);
     }
 
-    private sanitize(command: UpdateMyProfileCommand): UpdateMyProfileCommand {
+    private sanitize(role: ProfileUpdatableRole, command: UpdateMyProfileCommand): UpdateMyProfileCommand {
         const sanitized: UpdateMyProfileCommand = {};
+
         if (command.bio !== undefined) {
             const trimmed = command.bio.trim();
             if (trimmed.length > BIO_MAX_LENGTH) {
@@ -43,6 +48,41 @@ export class UpdateMyProfileUseCase {
             }
             sanitized.bio = trimmed;
         }
+
+        if (command.location !== undefined) {
+            if (role !== 'breeder') {
+                // 입양자 schema 에 사업장 위치 필드가 없다 — 명시적으로 거부.
+                throw new BadRequestException('사업장 위치는 브리더 계정에서만 편집할 수 있습니다.');
+            }
+            sanitized.location = this.sanitizeLocation(command.location);
+        }
+
         return sanitized;
+    }
+
+    private sanitizeLocation(location: UpdateMyProfileLocation): UpdateMyProfileLocation {
+        const result: UpdateMyProfileLocation = {};
+        if (location.city !== undefined) {
+            const trimmed = location.city.trim();
+            if (trimmed.length > LOCATION_CITY_MAX) {
+                throw new BadRequestException(`시는 ${LOCATION_CITY_MAX}자 이내여야 합니다.`);
+            }
+            result.city = trimmed;
+        }
+        if (location.district !== undefined) {
+            const trimmed = location.district.trim();
+            if (trimmed.length > LOCATION_DISTRICT_MAX) {
+                throw new BadRequestException(`구는 ${LOCATION_DISTRICT_MAX}자 이내여야 합니다.`);
+            }
+            result.district = trimmed;
+        }
+        if (location.address !== undefined) {
+            const trimmed = location.address.trim();
+            if (trimmed.length > LOCATION_ADDRESS_MAX) {
+                throw new BadRequestException(`상세 주소는 ${LOCATION_ADDRESS_MAX}자 이내여야 합니다.`);
+            }
+            result.address = trimmed;
+        }
+        return result;
     }
 }

--- a/src/api/profile/constants/profile-response-messages.ts
+++ b/src/api/profile/constants/profile-response-messages.ts
@@ -1,5 +1,6 @@
 export const PROFILE_RESPONSE_MESSAGES = {
     myRetrieved: '내 프로필 조회 성공',
+    myUpdated: '내 프로필 수정 성공',
     adopterRetrieved: '입양자 프로필 조회 성공',
     breederRetrieved: '브리더 프로필 조회 성공',
     favoriteBreedersRetrieved: '즐겨찾는 브리더 목록 조회 성공',

--- a/src/api/profile/controller/profile-me.controller.ts
+++ b/src/api/profile/controller/profile-me.controller.ts
@@ -51,7 +51,10 @@ export class ProfileMeController {
         if (role !== 'adopter' && role !== 'breeder') {
             throw new BadRequestException('지원하지 않는 사용자 역할입니다.');
         }
-        const result = await this.updateMyProfileUseCase.execute(userId, role, { bio: body.bio });
+        const result = await this.updateMyProfileUseCase.execute(userId, role, {
+            bio: body.bio,
+            location: body.location,
+        });
         return ApiResponseDto.success(result, PROFILE_RESPONSE_MESSAGES.myUpdated);
     }
 }

--- a/src/api/profile/controller/profile-me.controller.ts
+++ b/src/api/profile/controller/profile-me.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Get, Query } from '@nestjs/common';
+import { BadRequestException, Body, Get, Patch, Query } from '@nestjs/common';
 
 import { CurrentUser } from '../../../common/decorator/current-user.decorator';
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
@@ -6,22 +6,27 @@ import { PaginationResponseDto } from '../../../common/dto/pagination/pagination
 
 import { GetMyFavoriteBreedersUseCase } from '../application/use-cases/get-my-favorite-breeders.use-case';
 import { GetMyProfileUseCase } from '../application/use-cases/get-my-profile.use-case';
+import { UpdateMyProfileUseCase } from '../application/use-cases/update-my-profile.use-case';
 import { PROFILE_RESPONSE_MESSAGES } from '../constants/profile-response-messages';
 import {
     ProfileFavoritesController,
     ProfileMeController as ProfileMeControllerDecorator,
 } from '../decorator/profile-protected-controller.decorator';
 import { FavoriteBreedersQueryDto } from '../dto/request/favorite-breeders-query.dto';
+import { UpdateMyProfileRequestDto } from '../dto/request/update-my-profile-request.dto';
 import { FavoriteBreederCardResponseDto } from '../dto/response/favorite-breeder-card.dto';
 import { MyProfileResponseDto } from '../dto/response/my-profile-response.dto';
-import { ApiGetMyFavoriteBreedersEndpoint, ApiGetMyProfileEndpoint } from '../swagger';
+import { ApiGetMyFavoriteBreedersEndpoint, ApiGetMyProfileEndpoint, ApiUpdateMyProfileEndpoint } from '../swagger';
 
 /**
- * GET /v2/profile/me (인증 필수, role 무관)
+ * GET / PATCH /v2/profile/me (인증 필수, role 무관)
  */
 @ProfileMeControllerDecorator()
 export class ProfileMeController {
-    constructor(private readonly getMyProfileUseCase: GetMyProfileUseCase) {}
+    constructor(
+        private readonly getMyProfileUseCase: GetMyProfileUseCase,
+        private readonly updateMyProfileUseCase: UpdateMyProfileUseCase,
+    ) {}
 
     @Get('me')
     @ApiGetMyProfileEndpoint()
@@ -34,6 +39,20 @@ export class ProfileMeController {
         }
         const result = await this.getMyProfileUseCase.execute(userId, role);
         return ApiResponseDto.success(result, PROFILE_RESPONSE_MESSAGES.myRetrieved);
+    }
+
+    @Patch('me')
+    @ApiUpdateMyProfileEndpoint()
+    async updateMe(
+        @CurrentUser('userId') userId: string,
+        @CurrentUser('role') role: string,
+        @Body() body: UpdateMyProfileRequestDto,
+    ): Promise<ApiResponseDto<MyProfileResponseDto>> {
+        if (role !== 'adopter' && role !== 'breeder') {
+            throw new BadRequestException('지원하지 않는 사용자 역할입니다.');
+        }
+        const result = await this.updateMyProfileUseCase.execute(userId, role, { bio: body.bio });
+        return ApiResponseDto.success(result, PROFILE_RESPONSE_MESSAGES.myUpdated);
     }
 }
 

--- a/src/api/profile/dto/request/update-my-profile-request.dto.ts
+++ b/src/api/profile/dto/request/update-my-profile-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateMyProfileRequestDto {
+    @ApiPropertyOptional({
+        description: '한 줄 소개. trim 후 200자 이내. 빈 문자열은 한 줄 소개 비움을 의미한다.',
+        example: '도심속 도마뱀 사장님',
+        maxLength: 200,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    bio?: string;
+}

--- a/src/api/profile/dto/request/update-my-profile-request.dto.ts
+++ b/src/api/profile/dto/request/update-my-profile-request.dto.ts
@@ -1,5 +1,31 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsObject, IsOptional, IsString, MaxLength, ValidateNested } from 'class-validator';
+
+export class UpdateMyProfileLocationDto {
+    @ApiPropertyOptional({ description: '시 (예: "서울")', maxLength: 50, example: '서울' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(50)
+    city?: string;
+
+    @ApiPropertyOptional({ description: '구 (예: "금천구")', maxLength: 50, example: '금천구' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(50)
+    district?: string;
+
+    @ApiPropertyOptional({
+        description:
+            '상세 주소 (예: "독산로 OO길 OO"). PII 라 공개 응답(다른 사용자가 보는 브리더 프로필)에는 노출되지 않는다.',
+        maxLength: 200,
+        example: '독산로 12길 5',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    address?: string;
+}
 
 export class UpdateMyProfileRequestDto {
     @ApiPropertyOptional({
@@ -11,4 +37,15 @@ export class UpdateMyProfileRequestDto {
     @IsString()
     @MaxLength(200)
     bio?: string;
+
+    @ApiPropertyOptional({
+        description:
+            '사업장 위치 — 브리더 전용 (Figma 290:668 마이홈 "사업장 위치를 작성해주세요" CTA). 입양자가 보내면 400.',
+        type: UpdateMyProfileLocationDto,
+    })
+    @IsOptional()
+    @IsObject()
+    @ValidateNested()
+    @Type(() => UpdateMyProfileLocationDto)
+    location?: UpdateMyProfileLocationDto;
 }

--- a/src/api/profile/infrastructure/profile-writer-mongoose.adapter.ts
+++ b/src/api/profile/infrastructure/profile-writer-mongoose.adapter.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+    ProfileUpdatableRole,
+    ProfileWriterPort,
+    UpdateMyProfileCommand,
+} from '../application/ports/profile-writer.port';
+import { ProfileRepository } from '../repository/profile.repository';
+
+@Injectable()
+export class ProfileWriterMongooseAdapter implements ProfileWriterPort {
+    constructor(private readonly repository: ProfileRepository) {}
+
+    async updateMyProfile(
+        userId: string,
+        role: ProfileUpdatableRole,
+        command: UpdateMyProfileCommand,
+    ): Promise<boolean> {
+        if (role === 'adopter') {
+            return this.repository.updateAdopterProfile(userId, command);
+        }
+        return this.repository.updateBreederProfile(userId, command);
+    }
+}

--- a/src/api/profile/profile.module-definition.ts
+++ b/src/api/profile/profile.module-definition.ts
@@ -7,14 +7,20 @@ import { Breeder, BreederSchema } from '../../schema/breeder.schema';
 
 import { PROFILE_ASSET_URL_PORT } from './application/ports/profile-asset-url.port';
 import { PROFILE_READER_PORT } from './application/ports/profile-reader.port';
+import { PROFILE_WRITER_PORT } from './application/ports/profile-writer.port';
 import { GetAdopterProfileUseCase } from './application/use-cases/get-adopter-profile.use-case';
 import { GetBreederProfileUseCase } from './application/use-cases/get-breeder-profile.use-case';
 import { GetMyFavoriteBreedersUseCase } from './application/use-cases/get-my-favorite-breeders.use-case';
 import { GetMyProfileUseCase } from './application/use-cases/get-my-profile.use-case';
+import { UpdateMyProfileUseCase } from './application/use-cases/update-my-profile.use-case';
 import { ProfileMapperService } from './domain/services/profile-mapper.service';
 import { ProfileAssetUrlStorageAdapter } from './infrastructure/profile-asset-url-storage.adapter';
 import { ProfileReaderMongooseAdapter } from './infrastructure/profile-reader-mongoose.adapter';
-import { ProfileFavoriteBreedersController, ProfileMeController } from './controller/profile-me.controller';
+import { ProfileWriterMongooseAdapter } from './infrastructure/profile-writer-mongoose.adapter';
+import {
+    ProfileFavoriteBreedersController,
+    ProfileMeController,
+} from './controller/profile-me.controller';
 import { ProfilePublicController } from './controller/profile-public.controller';
 import { ProfileRepository } from './repository/profile.repository';
 
@@ -34,6 +40,7 @@ export const PROFILE_MODULE_CONTROLLERS = [
 
 const USE_CASE_PROVIDERS = [
     GetMyProfileUseCase,
+    UpdateMyProfileUseCase,
     GetAdopterProfileUseCase,
     GetBreederProfileUseCase,
     GetMyFavoriteBreedersUseCase,
@@ -41,10 +48,16 @@ const USE_CASE_PROVIDERS = [
 
 const DOMAIN_PROVIDERS = [ProfileMapperService];
 
-const INFRASTRUCTURE_PROVIDERS = [ProfileRepository, ProfileReaderMongooseAdapter, ProfileAssetUrlStorageAdapter];
+const INFRASTRUCTURE_PROVIDERS = [
+    ProfileRepository,
+    ProfileReaderMongooseAdapter,
+    ProfileWriterMongooseAdapter,
+    ProfileAssetUrlStorageAdapter,
+];
 
 const PORT_BINDINGS = [
     { provide: PROFILE_READER_PORT, useExisting: ProfileReaderMongooseAdapter },
+    { provide: PROFILE_WRITER_PORT, useExisting: ProfileWriterMongooseAdapter },
     { provide: PROFILE_ASSET_URL_PORT, useExisting: ProfileAssetUrlStorageAdapter },
 ];
 

--- a/src/api/profile/repository/profile.repository.ts
+++ b/src/api/profile/repository/profile.repository.ts
@@ -80,7 +80,7 @@ export class ProfileRepository {
     }
 
     /**
-     * 입양자 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     * 입양자 프로필 편집 (bio 만 지원 — Adopter 스키마에 location 없음). 도큐먼트 자체가 없으면 false.
      * 변경 항목이 없거나 동일 값이라도 true 로 처리 — 호출측 idempotent.
      */
     async updateAdopterProfile(userId: string, patch: { bio?: string }): Promise<boolean> {
@@ -100,12 +100,21 @@ export class ProfileRepository {
     }
 
     /**
-     * 브리더 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     * 브리더 프로필 편집 (bio + 사업장 위치). 도큐먼트 자체가 없으면 false.
+     * 위치 필드는 BreederProfile.location 의 city/district/address 에 dot-path 로 partial 적용.
      */
-    async updateBreederProfile(breederId: string, patch: { bio?: string }): Promise<boolean> {
+    async updateBreederProfile(
+        breederId: string,
+        patch: { bio?: string; location?: { city?: string; district?: string; address?: string } },
+    ): Promise<boolean> {
         if (!Types.ObjectId.isValid(breederId)) return false;
         const $set: Record<string, unknown> = {};
         if (patch.bio !== undefined) $set.bio = patch.bio;
+        if (patch.location !== undefined) {
+            if (patch.location.city !== undefined) $set['profile.location.city'] = patch.location.city;
+            if (patch.location.district !== undefined) $set['profile.location.district'] = patch.location.district;
+            if (patch.location.address !== undefined) $set['profile.location.address'] = patch.location.address;
+        }
 
         if (Object.keys($set).length === 0) {
             const exists = await this.breederModel.exists({ _id: new Types.ObjectId(breederId) });

--- a/src/api/profile/repository/profile.repository.ts
+++ b/src/api/profile/repository/profile.repository.ts
@@ -78,4 +78,43 @@ export class ProfileRepository {
         if (!adopter?.favoriteBreederList) return false;
         return adopter.favoriteBreederList.some((entry) => entry.favoriteBreederId === breederId);
     }
+
+    /**
+     * 입양자 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     * 변경 항목이 없거나 동일 값이라도 true 로 처리 — 호출측 idempotent.
+     */
+    async updateAdopterProfile(userId: string, patch: { bio?: string }): Promise<boolean> {
+        if (!Types.ObjectId.isValid(userId)) return false;
+        const $set: Record<string, unknown> = {};
+        if (patch.bio !== undefined) $set.bio = patch.bio;
+
+        if (Object.keys($set).length === 0) {
+            const exists = await this.adopterModel.exists({ _id: new Types.ObjectId(userId) });
+            return Boolean(exists);
+        }
+
+        const result = await this.adopterModel
+            .updateOne({ _id: new Types.ObjectId(userId) }, { $set })
+            .exec();
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * 브리더 프로필 편집 (현재는 bio 만 지원). 도큐먼트 자체가 없으면 false.
+     */
+    async updateBreederProfile(breederId: string, patch: { bio?: string }): Promise<boolean> {
+        if (!Types.ObjectId.isValid(breederId)) return false;
+        const $set: Record<string, unknown> = {};
+        if (patch.bio !== undefined) $set.bio = patch.bio;
+
+        if (Object.keys($set).length === 0) {
+            const exists = await this.breederModel.exists({ _id: new Types.ObjectId(breederId) });
+            return Boolean(exists);
+        }
+
+        const result = await this.breederModel
+            .updateOne({ _id: new Types.ObjectId(breederId) }, { $set })
+            .exec();
+        return result.matchedCount > 0;
+    }
 }

--- a/src/api/profile/swagger/index.ts
+++ b/src/api/profile/swagger/index.ts
@@ -44,12 +44,15 @@ export function ApiGetMyProfileEndpoint() {
 export function ApiUpdateMyProfileEndpoint() {
     return applyDecorators(
         ApiEndpoint({
-            summary: '내 프로필 수정 (마이홈, Figma 278:170 "프로필 편집")',
+            summary: '내 프로필 수정 (마이홈, Figma 278:170 "프로필 편집" + 290:668 "사업장 위치 작성")',
             description: `
                 현재 인증된 사용자의 프로필을 부분 수정한다. role 에 따라 Adopter/Breeder 도큐먼트에 적용.
 
-                ## 지원 필드 (이번 슬라이스)
+                ## 지원 필드
                 - bio (선택): 한 줄 소개. trim 후 200자 이내. 빈 문자열은 한 줄 소개 비움 의도.
+                - location (선택, 브리더 전용): 사업장 위치 — city / district / address 부분 수정.
+                  · Adopter 가 location 을 보내면 400 (Adopter 스키마에 해당 필드 없음).
+                  · address 는 PII 라 공개 응답(다른 사용자의 브리더 프로필 조회)에는 노출되지 않는다.
 
                 ## 응답
                 - 수정 후 GetMyProfile 와 동일한 응답 (계약 일관성)

--- a/src/api/profile/swagger/index.ts
+++ b/src/api/profile/swagger/index.ts
@@ -41,6 +41,27 @@ export function ApiGetMyProfileEndpoint() {
     );
 }
 
+export function ApiUpdateMyProfileEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '내 프로필 수정 (마이홈, Figma 278:170 "프로필 편집")',
+            description: `
+                현재 인증된 사용자의 프로필을 부분 수정한다. role 에 따라 Adopter/Breeder 도큐먼트에 적용.
+
+                ## 지원 필드 (이번 슬라이스)
+                - bio (선택): 한 줄 소개. trim 후 200자 이내. 빈 문자열은 한 줄 소개 비움 의도.
+
+                ## 응답
+                - 수정 후 GetMyProfile 와 동일한 응답 (계약 일관성)
+            `,
+            responseType: MyProfileResponseDto,
+            successDescription: '내 프로필 수정 성공',
+            successMessageExample: PROFILE_RESPONSE_MESSAGES.myUpdated,
+            errorResponses: [NOT_FOUND_RESPONSE],
+        }),
+    );
+}
+
 export function ApiGetAdopterProfileEndpoint() {
     return applyDecorators(
         ApiEndpoint({


### PR DESCRIPTION
## Summary

PR #92 위에 쌓는 후속 — 브리더 마이홈(Figma 290:668) "사업장 위치를 작성해주세요" CTA 처리.

- \`PATCH /v2/profile/me\` body 에 \`location?: { city?, district?, address? }\` 추가
- 브리더 전용 — 입양자가 보내면 400 (Adopter 스키마에 해당 필드 없음)
- repository 가 BreederProfile.location 의 city/district/address 를 dot-path partial \`\$set\` 으로 적용
- 각 필드 길이 검증 (city/district 50, address 200)
- swagger 에 PII 정책 명시 — address 는 다른 사용자의 브리더 공개 프로필 응답에서는 노출되지 않음 (#89 과 동일 컨벤션)

## Base

PR #92 (feat/v2-profile-update-me) 위에 스택. #92 의 ProfileWriterPort 와 UpdateMyProfileCommand 확장이라 #92 가 먼저 머지돼야 한다.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] e2e: 브리더 \`{ location: { district: '금천구' } }\` → BreederProfile.location.district 갱신
- [ ] e2e: 입양자 \`{ location: {...} }\` → 400
- [ ] e2e: 51자 city → 400
- [ ] e2e: address 갱신 후 \`GET /v2/profile/breeders/:id\` 응답에 address 노출 안 되는지 검증 (PII)

🤖 Generated with [Claude Code](https://claude.com/claude-code)