### PR TITLE
feat(adoption): v2 입양 리스트 status 필터 (Figma 678:49176/49772/52698) — #90 재작성

### DIFF
--- a/src/api/adoption/application/ports/adoption-pet-reader.port.ts
+++ b/src/api/adoption/application/ports/adoption-pet-reader.port.ts
@@ -6,6 +6,8 @@ export type AdoptionPetListQuery = {
     petType?: AdoptionPetType;
     breederId?: string;
     excludePetId?: string;
+    /** 분양 상태 필터 — 분양가능/예약중/분양완료 탭 (Figma 678:49176/49772/52698) */
+    status?: AdoptionPetStatus;
     sort: AdoptionPetSort;
     skip: number;
     limit: number;
@@ -60,7 +62,9 @@ export type AdoptionPetDetailSnapshot = AdoptionPetSnapshot & {
 export const ADOPTION_PET_READER_PORT = Symbol('ADOPTION_PET_READER_PORT');
 
 export interface AdoptionPetReaderPort {
-    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number>;
+    countList(
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+    ): Promise<number>;
     readList(query: AdoptionPetListQuery): Promise<AdoptionPetSnapshot[]>;
     readPopular(petType: AdoptionPetType | undefined, limit: number): Promise<AdoptionPetSnapshot[]>;
     readById(petId: string): Promise<AdoptionPetSnapshot | null>;

--- a/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
+++ b/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
@@ -12,6 +12,7 @@ import {
     type AdoptionPetListQuery,
     type AdoptionPetReaderPort,
     type AdoptionPetSnapshot,
+    type AdoptionPetStatus,
 } from '../ports/adoption-pet-reader.port';
 import type { AdoptionPetItemResult, AdoptionPetListResult } from '../types/adoption-result.type';
 
@@ -34,6 +35,7 @@ export class GetAdoptionPetListUseCase {
         petType?: AdoptionPetSnapshot['petType'];
         breederId?: string;
         excludePetId?: string;
+        status?: AdoptionPetStatus;
         sort?: AdoptionPetListQuery['sort'];
         page?: number;
         pageSize?: number;
@@ -47,6 +49,7 @@ export class GetAdoptionPetListUseCase {
             petType: input.petType,
             breederId: input.breederId,
             excludePetId: input.excludePetId,
+            status: input.status,
             sort,
             skip: (page - 1) * pageSize,
             limit: pageSize,
@@ -57,6 +60,7 @@ export class GetAdoptionPetListUseCase {
                 petType: input.petType,
                 breederId: input.breederId,
                 excludePetId: input.excludePetId,
+                status: input.status,
             }),
             this.petReader.readList(query),
         ]);

--- a/src/api/adoption/controller/adoption-list.controller.ts
+++ b/src/api/adoption/controller/adoption-list.controller.ts
@@ -31,6 +31,7 @@ export class AdoptionListController {
             petType: query.petType,
             breederId: query.breederId,
             excludePetId: query.excludePetId,
+            status: query.status,
             sort: query.sort,
             page: query.page,
             pageSize: query.pageSize,

--- a/src/api/adoption/dto/request/adoption-list-query.dto.ts
+++ b/src/api/adoption/dto/request/adoption-list-query.dto.ts
@@ -13,6 +13,12 @@ export enum AdoptionSortQuery {
     POPULAR = 'popular',
 }
 
+export enum AdoptionStatusQuery {
+    AVAILABLE = 'available',
+    RESERVED = 'reserved',
+    ADOPTED = 'adopted',
+}
+
 export class AdoptionListQueryDto {
     @ApiProperty({
         description: '동물 종류 필터 (전체는 미지정)',
@@ -40,6 +46,16 @@ export class AdoptionListQueryDto {
     @IsOptional()
     @IsMongoId()
     excludePetId?: string;
+
+    @ApiProperty({
+        description:
+            '분양 상태 필터 (Figma 678:49176 분양가능 / 678:49772 예약중 / 678:52698 분양완료 탭). 미지정 시 전체 노출.',
+        enum: AdoptionStatusQuery,
+        required: false,
+    })
+    @IsOptional()
+    @IsEnum(AdoptionStatusQuery)
+    status?: AdoptionStatusQuery;
 
     @ApiProperty({
         description: '정렬 기준',

--- a/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
+++ b/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
@@ -14,7 +14,9 @@ import { AdoptionPetRepository } from '../repository/adoption-pet.repository';
 export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
     constructor(private readonly repository: AdoptionPetRepository) {}
 
-    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number> {
+    countList(
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+    ): Promise<number> {
         return this.repository.countList(query);
     }
 

--- a/src/api/adoption/repository/adoption-pet.repository.ts
+++ b/src/api/adoption/repository/adoption-pet.repository.ts
@@ -3,7 +3,11 @@ import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';
 
 import { AvailablePet } from '../../../schema/available-pet.schema';
-import type { AdoptionPetListQuery, AdoptionPetType } from '../application/ports/adoption-pet-reader.port';
+import type {
+    AdoptionPetListQuery,
+    AdoptionPetStatus,
+    AdoptionPetType,
+} from '../application/ports/adoption-pet-reader.port';
 
 @Injectable()
 export class AdoptionPetRepository {
@@ -13,6 +17,7 @@ export class AdoptionPetRepository {
         petType?: AdoptionPetType;
         breederId?: string;
         excludePetId?: string;
+        status?: AdoptionPetStatus;
     }): FilterQuery<AvailablePet> {
         const filter: FilterQuery<AvailablePet> = { isActive: true };
         if (input.petType) {
@@ -24,10 +29,15 @@ export class AdoptionPetRepository {
         if (input.excludePetId && Types.ObjectId.isValid(input.excludePetId)) {
             filter._id = { $ne: new Types.ObjectId(input.excludePetId) };
         }
+        if (input.status) {
+            filter.status = input.status;
+        }
         return filter;
     }
 
-    countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number> {
+    countList(
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+    ): Promise<number> {
         return this.model.countDocuments(this.buildBaseFilter(query)).exec();
     }
 

--- a/src/api/adoption/swagger/index.ts
+++ b/src/api/adoption/swagger/index.ts
@@ -40,6 +40,7 @@ export function ApiGetAdoptionListEndpoint() {
                 - petType 필터 (강아지/고양이/도마뱀)
                 - breederId 필터 (특정 브리더의 분양 동물만)
                 - excludePetId (특정 펫을 결과에서 제외 — 상세 화면 자기 자신 제외용)
+                - status 필터 (분양가능/예약중/분양완료 탭 — Figma 678:49176/49772/52698)
                 - 정렬: 최신순(latest) / 인기순(popular)
                 - 인증 사용자는 카드별 isFavorited 가 채워집니다
             `,
@@ -52,6 +53,12 @@ export function ApiGetAdoptionListEndpoint() {
         }),
         ApiQuery({ name: 'breederId', required: false, type: String, description: '특정 브리더 필터 (ObjectId)' }),
         ApiQuery({ name: 'excludePetId', required: false, type: String, description: '결과에서 제외할 펫 ID' }),
+        ApiQuery({
+            name: 'status',
+            required: false,
+            enum: ['available', 'reserved', 'adopted'],
+            description: '분양 상태 필터',
+        }),
     );
 }
 


### PR DESCRIPTION
## Summary

분양 페이지의 분양가능/예약중/분양완료 탭 (Figma 678:49176/49772/52698) 을 위해 \`GET /v2/adoption\` 에 \`status\` 쿼리 파라미터 추가.

| Figma 노드 | API |
|---|---|
| 678:49176 분양가능 | \`GET /v2/adoption?status=available\` |
| 678:49772 예약중 | \`GET /v2/adoption?status=reserved\` |
| 678:52698 분양완료 | \`GET /v2/adoption?status=adopted\` |

## #90 재작성 사유

PR #90 (\`feat/v2-adoption-list-status-filter\`) 는 stale 한 PR #89 위에 쌓여 있었음. #89 와 동등한 변경이 별도 PR (\`feat/v2-adoption-detail-restore\`) 로 dev 에 머지되면서 #89/#90 둘 다 stale → 본 PR 은 dev 기반 fresh.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] e2e: status=available 만 available 카드 / reserved 만 reserved / adopted 만 adopted 노출
- [ ] e2e: status 미지정 시 전체 노출 (회귀 차단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)