### PR TITLE
feat(breeder-pet-posting): v2 PATCH/DELETE /v2/breeder-pet-posting/:petId

### DIFF
--- a/src/api/breeder-pet-posting/application/ports/breeder-pet-posting-writer.port.ts
+++ b/src/api/breeder-pet-posting/application/ports/breeder-pet-posting-writer.port.ts
@@ -1,7 +1,26 @@
-import type { BreederPetPostingCreatePersistData } from '../types/breeder-pet-posting-command.type';
+import type {
+    BreederPetPostingCreatePersistData,
+    BreederPetPostingUpdatePersistData,
+} from '../types/breeder-pet-posting-command.type';
 
 export const BREEDER_PET_POSTING_WRITER_PORT = Symbol('BREEDER_PET_POSTING_WRITER_PORT');
 
 export interface BreederPetPostingWriterPort {
     create(data: BreederPetPostingCreatePersistData): Promise<{ petId: string }>;
+
+    /**
+     * 작성자(breederId) 본인 + isActive=true 인 분양글만 갱신한다.
+     * 본인 글 아니거나(다른 브리더 소유) 비활성/미존재면 changed=false 로 반환 — 호출측이 404 매핑.
+     */
+    updateByOwner(
+        petId: string,
+        breederId: string,
+        patch: BreederPetPostingUpdatePersistData,
+    ): Promise<{ changed: boolean }>;
+
+    /**
+     * 작성자 본인 + isActive=true 인 분양글을 soft delete (isActive=false).
+     * 다른 도메인(adoption-application, favorite 등)이 참조하므로 hard delete 하지 않는다.
+     */
+    softDeleteByOwner(petId: string, breederId: string): Promise<{ changed: boolean }>;
 }

--- a/src/api/breeder-pet-posting/application/types/breeder-pet-posting-command.type.ts
+++ b/src/api/breeder-pet-posting/application/types/breeder-pet-posting-command.type.ts
@@ -111,3 +111,48 @@ export interface BreederPetPostingCreatePersistData {
 export interface BreederPetPostingCreateResult {
     petId: string;
 }
+
+/**
+ * v2 분양글 부분 수정 command.
+ *
+ * 본 슬라이스는 단순 / 안전 필드만 지원한다:
+ * - 기본 정보 (name, breed, gender, birthDate, price, description, petType)
+ * - 분양 상태 전환 (status: available / reserved / adopted)
+ * - 사진 (photos / representativePhotoIndex)
+ *
+ * 복잡 필드(vaccination/geneticTest/parents/breedingEnvironment) 는 cross-field validation
+ * 부담이 커서 별도 PR 로 분리한다. 본 PR 의 update 는 위 화이트리스트 외의 필드를 받지 않는다.
+ */
+export interface BreederPetPostingUpdateCommand {
+    name?: string;
+    breed?: string;
+    gender?: PostingGender;
+    birthDate?: string;
+    price?: number;
+    description?: string;
+    petType?: PostingPetType;
+    status?: 'available' | 'reserved' | 'adopted';
+    photos?: string[];
+    representativePhotoIndex?: number;
+}
+
+/**
+ * persist 단계 — Date 캐스팅 등 적용 후 Mongoose $set 에 그대로 전달 가능한 모양.
+ */
+export interface BreederPetPostingUpdatePersistData {
+    name?: string;
+    breed?: string;
+    gender?: PostingGender;
+    birthDate?: Date;
+    price?: number;
+    description?: string;
+    petType?: PostingPetType;
+    status?: 'available' | 'reserved' | 'adopted';
+    photos?: string[];
+    representativePhotoIndex?: number;
+}
+
+export interface BreederPetPostingDeleteResult {
+    petId: string;
+    deleted: boolean;
+}

--- a/src/api/breeder-pet-posting/application/use-cases/delete-breeder-pet-posting.use-case.ts
+++ b/src/api/breeder-pet-posting/application/use-cases/delete-breeder-pet-posting.use-case.ts
@@ -1,0 +1,42 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import {
+    BREEDER_PET_POSTING_PROFILE_PORT,
+    type BreederPetPostingProfilePort,
+} from '../ports/breeder-pet-posting-profile.port';
+import {
+    BREEDER_PET_POSTING_WRITER_PORT,
+    type BreederPetPostingWriterPort,
+} from '../ports/breeder-pet-posting-writer.port';
+import type { BreederPetPostingDeleteResult } from '../types/breeder-pet-posting-command.type';
+
+/**
+ * v2 분양글 soft delete use-case (브리더 본인 전용).
+ *
+ * - isActive=false 로 마킹. 다른 도메인이 참조하는 도큐먼트는 보존한다.
+ * - 본인 글이 아니거나 이미 비활성/미존재면 BadRequestException ("해당 분양글을 찾을 수 없습니다.")
+ * - 이미 비활성인 도큐먼트에 다시 호출하는 경우도 동일 — 미존재처럼 처리 (idempotent 아님)
+ */
+@Injectable()
+export class DeleteBreederPetPostingUseCase {
+    constructor(
+        @Inject(BREEDER_PET_POSTING_PROFILE_PORT)
+        private readonly profilePort: BreederPetPostingProfilePort,
+        @Inject(BREEDER_PET_POSTING_WRITER_PORT)
+        private readonly writerPort: BreederPetPostingWriterPort,
+    ) {}
+
+    async execute(userId: string, petId: string): Promise<BreederPetPostingDeleteResult> {
+        const breeder = await this.profilePort.findById(userId);
+        if (!breeder) {
+            throw new BadRequestException('브리더 정보를 찾을 수 없습니다.');
+        }
+
+        const { changed } = await this.writerPort.softDeleteByOwner(petId, breeder.breederId);
+        if (!changed) {
+            throw new BadRequestException('해당 분양글을 찾을 수 없습니다.');
+        }
+
+        return { petId, deleted: true };
+    }
+}

--- a/src/api/breeder-pet-posting/application/use-cases/update-breeder-pet-posting.use-case.ts
+++ b/src/api/breeder-pet-posting/application/use-cases/update-breeder-pet-posting.use-case.ts
@@ -1,0 +1,89 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import {
+    BREEDER_PET_POSTING_PROFILE_PORT,
+    type BreederPetPostingProfilePort,
+} from '../ports/breeder-pet-posting-profile.port';
+import {
+    BREEDER_PET_POSTING_WRITER_PORT,
+    type BreederPetPostingWriterPort,
+} from '../ports/breeder-pet-posting-writer.port';
+import type {
+    BreederPetPostingUpdateCommand,
+    BreederPetPostingUpdatePersistData,
+} from '../types/breeder-pet-posting-command.type';
+
+const MAX_PHOTOS = 10;
+const MIN_PHOTOS = 1;
+
+/**
+ * v2 분양글 부분 수정 use-case (브리더 본인 전용).
+ *
+ * - StrictRolesGuard('breeder') 가 컨트롤러 단에서 role 강제
+ * - 본인 글 아니거나 비활성/미존재면 BadRequestException ("해당 분양글을 찾을 수 없습니다.")
+ *   → 다른 브리더 소유 정보 누설 방지를 위해 403 대신 400 으로 통일
+ *
+ * 입력 필드 화이트리스트는 BreederPetPostingUpdateCommand 가 정의한다.
+ */
+@Injectable()
+export class UpdateBreederPetPostingUseCase {
+    constructor(
+        @Inject(BREEDER_PET_POSTING_PROFILE_PORT)
+        private readonly profilePort: BreederPetPostingProfilePort,
+        @Inject(BREEDER_PET_POSTING_WRITER_PORT)
+        private readonly writerPort: BreederPetPostingWriterPort,
+    ) {}
+
+    async execute(userId: string, petId: string, command: BreederPetPostingUpdateCommand): Promise<{ petId: string }> {
+        const breeder = await this.profilePort.findById(userId);
+        if (!breeder) {
+            throw new BadRequestException('브리더 정보를 찾을 수 없습니다.');
+        }
+
+        const persistData = this.toPersistData(command);
+
+        const { changed } = await this.writerPort.updateByOwner(petId, breeder.breederId, persistData);
+        if (!changed) {
+            throw new BadRequestException('해당 분양글을 찾을 수 없습니다.');
+        }
+
+        return { petId };
+    }
+
+    private toPersistData(command: BreederPetPostingUpdateCommand): BreederPetPostingUpdatePersistData {
+        // photos 가 제공된 경우만 길이 + 대표 인덱스 검증 (cross-field).
+        // 미제공이면 기존 photos 그대로 — DB 상태와 정합성은 그대로 유지된다.
+        if (command.photos !== undefined) {
+            if (command.photos.length < MIN_PHOTOS) {
+                throw new BadRequestException('이미지를 최소 1장 이상 업로드해주세요.');
+            }
+            if (command.photos.length > MAX_PHOTOS) {
+                throw new BadRequestException(`이미지는 최대 ${MAX_PHOTOS}장까지 업로드할 수 있습니다.`);
+            }
+            const index = command.representativePhotoIndex ?? 0;
+            if (index < 0 || index >= command.photos.length) {
+                throw new BadRequestException('대표 사진 인덱스가 업로드된 이미지 범위를 벗어났습니다.');
+            }
+        } else if (command.representativePhotoIndex !== undefined) {
+            // photos 없이 대표 인덱스만 변경 — 클라이언트가 기존 photos 길이를 신뢰. 음수만 차단.
+            if (command.representativePhotoIndex < 0) {
+                throw new BadRequestException('대표 사진 인덱스가 유효하지 않습니다.');
+            }
+        }
+
+        const persist: BreederPetPostingUpdatePersistData = {};
+        if (command.name !== undefined) persist.name = command.name;
+        if (command.breed !== undefined) persist.breed = command.breed;
+        if (command.gender !== undefined) persist.gender = command.gender;
+        if (command.birthDate !== undefined) persist.birthDate = new Date(command.birthDate);
+        if (command.price !== undefined) persist.price = command.price;
+        if (command.description !== undefined) persist.description = command.description;
+        if (command.petType !== undefined) persist.petType = command.petType;
+        if (command.status !== undefined) persist.status = command.status;
+        if (command.photos !== undefined) persist.photos = command.photos;
+        if (command.representativePhotoIndex !== undefined) {
+            persist.representativePhotoIndex = command.representativePhotoIndex;
+        }
+        return persist;
+    }
+}

--- a/src/api/breeder-pet-posting/breeder-pet-posting.module-definition.ts
+++ b/src/api/breeder-pet-posting/breeder-pet-posting.module-definition.ts
@@ -9,9 +9,12 @@ import { BREEDER_PET_POSTING_PROFILE_PORT } from './application/ports/breeder-pe
 import { BREEDER_PET_POSTING_READER_PORT } from './application/ports/breeder-pet-posting-reader.port';
 import { BREEDER_PET_POSTING_WRITER_PORT } from './application/ports/breeder-pet-posting-writer.port';
 import { CreateBreederPetPostingUseCase } from './application/use-cases/create-breeder-pet-posting.use-case';
+import { DeleteBreederPetPostingUseCase } from './application/use-cases/delete-breeder-pet-posting.use-case';
 import { ListMyBreederPetPostingsUseCase } from './application/use-cases/list-my-breeder-pet-postings.use-case';
+import { UpdateBreederPetPostingUseCase } from './application/use-cases/update-breeder-pet-posting.use-case';
 import { BreederPetPostingCreateController } from './controller/breeder-pet-posting-create.controller';
 import { BreederPetPostingListController } from './controller/breeder-pet-posting-list.controller';
+import { BreederPetPostingUpdateController } from './controller/breeder-pet-posting-update.controller';
 import { BreederPetPostingCardMapperService } from './domain/services/breeder-pet-posting-card-mapper.service';
 import { BreederPetPostingMapperService } from './domain/services/breeder-pet-posting-mapper.service';
 import { BreederPetPostingValidatorService } from './domain/services/breeder-pet-posting-validator.service';
@@ -31,9 +34,15 @@ export const BREEDER_PET_POSTING_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule
 export const BREEDER_PET_POSTING_MODULE_CONTROLLERS = [
     BreederPetPostingCreateController,
     BreederPetPostingListController,
+    BreederPetPostingUpdateController,
 ];
 
-const USE_CASE_PROVIDERS = [CreateBreederPetPostingUseCase, ListMyBreederPetPostingsUseCase];
+const USE_CASE_PROVIDERS = [
+    CreateBreederPetPostingUseCase,
+    ListMyBreederPetPostingsUseCase,
+    UpdateBreederPetPostingUseCase,
+    DeleteBreederPetPostingUseCase,
+];
 
 const DOMAIN_PROVIDERS = [
     BreederPetPostingValidatorService,

--- a/src/api/breeder-pet-posting/constants/breeder-pet-posting-response-messages.ts
+++ b/src/api/breeder-pet-posting/constants/breeder-pet-posting-response-messages.ts
@@ -1,4 +1,6 @@
 export const BREEDER_PET_POSTING_RESPONSE_MESSAGES = {
     created: '분양글이 성공적으로 업로드 되었습니다.',
     myListRetrieved: '내 분양글 목록 조회 성공',
+    updated: '분양글이 수정되었습니다.',
+    deleted: '분양글이 삭제되었습니다.',
 } as const;

--- a/src/api/breeder-pet-posting/controller/breeder-pet-posting-update.controller.ts
+++ b/src/api/breeder-pet-posting/controller/breeder-pet-posting-update.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Delete, Param, Patch } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { MongoObjectIdPipe } from '../../../common/pipe/mongo-object-id.pipe';
+
+import { DeleteBreederPetPostingUseCase } from '../application/use-cases/delete-breeder-pet-posting.use-case';
+import { UpdateBreederPetPostingUseCase } from '../application/use-cases/update-breeder-pet-posting.use-case';
+import { BREEDER_PET_POSTING_RESPONSE_MESSAGES } from '../constants/breeder-pet-posting-response-messages';
+import { BreederPetPostingProtectedController } from '../decorator/breeder-pet-posting-protected-controller.decorator';
+import { UpdateBreederPetPostingRequestDto } from '../dto/request/breeder-pet-posting-update-request.dto';
+import { BreederPetPostingDeleteResponseDto } from '../dto/response/breeder-pet-posting-delete-response.dto';
+import { CreateBreederPetPostingResponseDto } from '../dto/response/breeder-pet-posting-response.dto';
+import { ApiDeleteBreederPetPostingEndpoint, ApiUpdateBreederPetPostingEndpoint } from '../swagger';
+
+/**
+ * v2 분양글 수정/삭제 컨트롤러 (브리더 본인 전용).
+ *
+ * 보류된 PR (PATCH/DELETE /v2/breeder-pet-posting/:petId) 의 백엔드 진입점.
+ * cross-field 검증이 복잡한 health/parent/environment 필드는 별도 PR 로 분리한다.
+ */
+@BreederPetPostingProtectedController()
+export class BreederPetPostingUpdateController {
+    constructor(
+        private readonly updateUseCase: UpdateBreederPetPostingUseCase,
+        private readonly deleteUseCase: DeleteBreederPetPostingUseCase,
+    ) {}
+
+    @Patch(':petId')
+    @ApiUpdateBreederPetPostingEndpoint()
+    async update(
+        @CurrentUser('userId') userId: string,
+        @Param('petId', new MongoObjectIdPipe('분양글')) petId: string,
+        @Body() body: UpdateBreederPetPostingRequestDto,
+    ): Promise<ApiResponseDto<CreateBreederPetPostingResponseDto>> {
+        const result = await this.updateUseCase.execute(userId, petId, body);
+        return ApiResponseDto.success({ petId: result.petId }, BREEDER_PET_POSTING_RESPONSE_MESSAGES.updated);
+    }
+
+    @Delete(':petId')
+    @ApiDeleteBreederPetPostingEndpoint()
+    async delete(
+        @CurrentUser('userId') userId: string,
+        @Param('petId', new MongoObjectIdPipe('분양글')) petId: string,
+    ): Promise<ApiResponseDto<BreederPetPostingDeleteResponseDto>> {
+        const result = await this.deleteUseCase.execute(userId, petId);
+        return ApiResponseDto.success(result, BREEDER_PET_POSTING_RESPONSE_MESSAGES.deleted);
+    }
+}

--- a/src/api/breeder-pet-posting/dto/request/breeder-pet-posting-update-request.dto.ts
+++ b/src/api/breeder-pet-posting/dto/request/breeder-pet-posting-update-request.dto.ts
@@ -1,0 +1,96 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+    ArrayMaxSize,
+    ArrayMinSize,
+    IsArray,
+    IsDateString,
+    IsEnum,
+    IsInt,
+    IsNotEmpty,
+    IsNumber,
+    IsOptional,
+    IsString,
+    Max,
+    MaxLength,
+    Min,
+} from 'class-validator';
+
+/**
+ * v2 분양글 부분 수정 요청 DTO.
+ *
+ * 본 슬라이스 화이트리스트: 단순/안전 필드 위주.
+ * vaccination/geneticTest/parents/breedingEnvironment 처럼 cross-field validation 이 복잡한
+ * 필드는 받지 않는다 (서버에서 무시) — use-case 의 PersistData 도 해당 필드를 포함하지 않는다.
+ */
+export class UpdateBreederPetPostingRequestDto {
+    @ApiPropertyOptional({ description: '품종 및 이름', example: '레오파드게코 도마뱀(만다린)' })
+    @IsOptional()
+    @IsString()
+    @IsNotEmpty()
+    name?: string;
+
+    @ApiPropertyOptional({ description: '품종 (검색용 normalized)', example: '레오파드게코' })
+    @IsOptional()
+    @IsString()
+    @IsNotEmpty()
+    breed?: string;
+
+    @ApiPropertyOptional({ description: '성별', enum: ['male', 'female'], example: 'female' })
+    @IsOptional()
+    @IsEnum(['male', 'female'])
+    gender?: 'male' | 'female';
+
+    @ApiPropertyOptional({ description: '태어난 날짜 (YYYY-MM-DD)', example: '2024-11-05' })
+    @IsOptional()
+    @IsDateString()
+    birthDate?: string;
+
+    @ApiPropertyOptional({ description: '분양가 (원)', example: 200000, minimum: 0 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsNumber()
+    @Min(0)
+    price?: number;
+
+    @ApiPropertyOptional({ description: '아이 소개', example: '귀여운 파이리', maxLength: 500 })
+    @IsOptional()
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(500)
+    description?: string;
+
+    @ApiPropertyOptional({ description: '동물 종류', enum: ['dog', 'cat', 'reptile'] })
+    @IsOptional()
+    @IsEnum(['dog', 'cat', 'reptile'])
+    petType?: 'dog' | 'cat' | 'reptile';
+
+    @ApiPropertyOptional({
+        description: '분양 상태 전환 (분양가능 → 예약중 → 분양완료)',
+        enum: ['available', 'reserved', 'adopted'],
+    })
+    @IsOptional()
+    @IsEnum(['available', 'reserved', 'adopted'])
+    status?: 'available' | 'reserved' | 'adopted';
+
+    @ApiPropertyOptional({
+        description: '이미지 파일명 배열 (1~10장, 갱신 시 전체 교체)',
+        type: [String],
+        minItems: 1,
+        maxItems: 10,
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMinSize(1)
+    @ArrayMaxSize(10)
+    @IsString({ each: true })
+    photos?: string[];
+
+    @ApiPropertyOptional({ description: '대표 사진 인덱스', example: 0, minimum: 0, maximum: 9 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    @Max(9)
+    representativePhotoIndex?: number;
+}

--- a/src/api/breeder-pet-posting/dto/response/breeder-pet-posting-delete-response.dto.ts
+++ b/src/api/breeder-pet-posting/dto/response/breeder-pet-posting-delete-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BreederPetPostingDeleteResponseDto {
+    @ApiProperty({ description: '삭제된 분양글 ID', example: '507f1f77bcf86cd799439011' })
+    petId: string;
+
+    @ApiProperty({ description: '소프트 삭제 여부 (isActive=false 마킹 성공)', example: true })
+    deleted: boolean;
+}

--- a/src/api/breeder-pet-posting/infrastructure/breeder-pet-posting-writer-mongoose.adapter.ts
+++ b/src/api/breeder-pet-posting/infrastructure/breeder-pet-posting-writer-mongoose.adapter.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
 import type { BreederPetPostingWriterPort } from '../application/ports/breeder-pet-posting-writer.port';
-import type { BreederPetPostingCreatePersistData } from '../application/types/breeder-pet-posting-command.type';
+import type {
+    BreederPetPostingCreatePersistData,
+    BreederPetPostingUpdatePersistData,
+} from '../application/types/breeder-pet-posting-command.type';
 import { BreederPetPostingRepository } from '../repository/breeder-pet-posting.repository';
 
 @Injectable()
@@ -11,5 +14,17 @@ export class BreederPetPostingWriterMongooseAdapter implements BreederPetPosting
     async create(data: BreederPetPostingCreatePersistData): Promise<{ petId: string }> {
         const created = await this.repository.create(data);
         return { petId: created._id };
+    }
+
+    updateByOwner(
+        petId: string,
+        breederId: string,
+        patch: BreederPetPostingUpdatePersistData,
+    ): Promise<{ changed: boolean }> {
+        return this.repository.updateByOwner(petId, breederId, patch);
+    }
+
+    softDeleteByOwner(petId: string, breederId: string): Promise<{ changed: boolean }> {
+        return this.repository.softDeleteByOwner(petId, breederId);
     }
 }

--- a/src/api/breeder-pet-posting/repository/breeder-pet-posting.repository.ts
+++ b/src/api/breeder-pet-posting/repository/breeder-pet-posting.repository.ts
@@ -3,7 +3,10 @@ import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';
 
 import { AvailablePet, AvailablePetDocument } from '../../../schema/available-pet.schema';
-import type { BreederPetPostingCreatePersistData } from '../application/types/breeder-pet-posting-command.type';
+import type {
+    BreederPetPostingCreatePersistData,
+    BreederPetPostingUpdatePersistData,
+} from '../application/types/breeder-pet-posting-command.type';
 
 export type BreederPetPostingStatus = 'available' | 'reserved' | 'adopted';
 
@@ -57,5 +60,70 @@ export class BreederPetPostingRepository {
         ]);
 
         return { docs, totalItems };
+    }
+
+    /**
+     * 본인 분양글만 갱신. petId+breederId+isActive=true 매칭 필터로 단일 updateOne.
+     * 매칭이 0건이면 changed=false (다른 브리더 소유 / 비활성 / 미존재 모두 동일하게 처리).
+     */
+    async updateByOwner(
+        petId: string,
+        breederId: string,
+        patch: BreederPetPostingUpdatePersistData,
+    ): Promise<{ changed: boolean }> {
+        if (!Types.ObjectId.isValid(petId) || !Types.ObjectId.isValid(breederId)) {
+            return { changed: false };
+        }
+
+        const $set: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(patch)) {
+            if (value !== undefined) {
+                $set[key] = value;
+            }
+        }
+
+        if (Object.keys($set).length === 0) {
+            // 빈 patch 는 본인 글 존재 여부만 확인 — idempotent
+            const exists = await this.availablePetModel.exists({
+                _id: new Types.ObjectId(petId),
+                breederId: new Types.ObjectId(breederId),
+                isActive: true,
+            });
+            return { changed: Boolean(exists) };
+        }
+
+        const result = await this.availablePetModel
+            .updateOne(
+                {
+                    _id: new Types.ObjectId(petId),
+                    breederId: new Types.ObjectId(breederId),
+                    isActive: true,
+                },
+                { $set },
+            )
+            .exec();
+
+        return { changed: result.matchedCount > 0 };
+    }
+
+    /**
+     * 본인 분양글 soft delete — isActive=false.
+     * 다른 도메인(상담 신청/즐겨찾기 등)이 참조하므로 도큐먼트는 보존한다.
+     */
+    async softDeleteByOwner(petId: string, breederId: string): Promise<{ changed: boolean }> {
+        if (!Types.ObjectId.isValid(petId) || !Types.ObjectId.isValid(breederId)) {
+            return { changed: false };
+        }
+        const result = await this.availablePetModel
+            .updateOne(
+                {
+                    _id: new Types.ObjectId(petId),
+                    breederId: new Types.ObjectId(breederId),
+                    isActive: true,
+                },
+                { $set: { isActive: false } },
+            )
+            .exec();
+        return { changed: result.modifiedCount > 0 };
     }
 }

--- a/src/api/breeder-pet-posting/swagger/index.ts
+++ b/src/api/breeder-pet-posting/swagger/index.ts
@@ -1,4 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
 
 import {
     ApiController,
@@ -8,6 +9,7 @@ import {
 import { PaginationResponseDto } from '../../../common/dto/pagination/pagination-response.dto';
 import { BREEDER_PET_POSTING_RESPONSE_MESSAGES } from '../constants/breeder-pet-posting-response-messages';
 import { BreederPetPostingCardResponseDto } from '../dto/response/breeder-pet-posting-card.dto';
+import { BreederPetPostingDeleteResponseDto } from '../dto/response/breeder-pet-posting-delete-response.dto';
 import { CreateBreederPetPostingResponseDto } from '../dto/response/breeder-pet-posting-response.dto';
 
 const BREEDER_NOT_FOUND_RESPONSE = {
@@ -20,6 +22,12 @@ const VALIDATION_ERROR_RESPONSE = {
     status: 400,
     description: '입력 검증 실패',
     errorExample: '이미지를 최소 1장 이상 업로드해주세요.',
+} as const;
+
+const POSTING_NOT_FOUND_RESPONSE = {
+    status: 400,
+    description: '분양글 미존재 / 본인 글 아님',
+    errorExample: '해당 분양글을 찾을 수 없습니다.',
 } as const;
 
 export function ApiBreederPetPostingProtectedController() {
@@ -52,6 +60,59 @@ export function ApiCreateBreederPetPostingEndpoint() {
             successMessageExample: BREEDER_PET_POSTING_RESPONSE_MESSAGES.created,
             errorResponses: [VALIDATION_ERROR_RESPONSE, BREEDER_NOT_FOUND_RESPONSE],
         }),
+    );
+}
+
+export function ApiUpdateBreederPetPostingEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '분양글 부분 수정 (v2, 작성자 본인)',
+            description: `
+                v2 분양글의 단순/안전 필드를 부분 수정한다.
+
+                ## 지원 필드 (화이트리스트)
+                - name, breed, gender, birthDate, price, description, petType
+                - status (분양 상태 전환: available / reserved / adopted)
+                - photos / representativePhotoIndex (photos 제공 시 1~10 + 대표 인덱스 범위 검증)
+
+                ## 제외된 필드
+                - vaccinationStatus/Records/IncompleteReason
+                - geneticTestStatus/Records/IncompleteReason
+                - parentPetSnapshots
+                - breedingEnvironment
+
+                위 필드들은 cross-field 정합성이 복잡하여 별도 PR 에서 다룬다. 본 endpoint 에 보내면 무시된다.
+
+                ## 권한
+                - JWT 인증 + StrictRolesGuard('breeder')
+                - 본인 글이 아니거나 이미 비활성/미존재면 400 ("해당 분양글을 찾을 수 없습니다.") — 다른 브리더 소유 정보 누설 방지를 위해 403 대신 400 통일
+            `,
+            responseType: CreateBreederPetPostingResponseDto,
+            successDescription: '분양글 수정 성공',
+            successMessageExample: BREEDER_PET_POSTING_RESPONSE_MESSAGES.updated,
+            errorResponses: [VALIDATION_ERROR_RESPONSE, BREEDER_NOT_FOUND_RESPONSE, POSTING_NOT_FOUND_RESPONSE],
+        }),
+        ApiParam({ name: 'petId', description: '분양글(펫) ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
+export function ApiDeleteBreederPetPostingEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '분양글 삭제 (v2, soft, 작성자 본인)',
+            description: `
+                v2 분양글을 isActive=false 로 soft delete 한다.
+
+                - 다른 도메인(상담 신청/즐겨찾기 등)이 참조하므로 도큐먼트는 보존한다.
+                - 본인 글이 아니거나 이미 비활성/미존재면 400 ("해당 분양글을 찾을 수 없습니다.")
+                - 권한: JWT + StrictRolesGuard('breeder')
+            `,
+            responseType: BreederPetPostingDeleteResponseDto,
+            successDescription: '분양글 삭제 성공',
+            successMessageExample: BREEDER_PET_POSTING_RESPONSE_MESSAGES.deleted,
+            errorResponses: [BREEDER_NOT_FOUND_RESPONSE, POSTING_NOT_FOUND_RESPONSE],
+        }),
+        ApiParam({ name: 'petId', description: '분양글(펫) ID', example: '507f1f77bcf86cd799439011' }),
     );
 }
 


### PR DESCRIPTION
## Summary

마이홈 분양목록 탭의 카드별 편집/삭제, 분양 상태 전환(분양가능→예약중→분양완료) 흐름을 처리하는 endpoint.

| 메서드 | 라우트 | 동작 |
|---|---|---|
| PATCH | \`/v2/breeder-pet-posting/:petId\` | 작성자 본인 부분 수정 |
| DELETE | \`/v2/breeder-pet-posting/:petId\` | 작성자 본인 soft delete |

## PATCH 지원 필드 (이번 슬라이스)

- 기본 정보: name, breed, gender, birthDate, price, description, petType
- 분양 상태: status (available / reserved / adopted) — 분양 상태 탭 (#94) 데이터의 쓰기 경로
- 사진: photos / representativePhotoIndex — photos 갱신 시 1~10 + 대표 인덱스 범위 검증

vaccination/geneticTest/parents/breedingEnvironment 는 cross-field 정합성이 복잡해 본 PR 에서 제외, 별도 PR 에서 다룬다 (DTO 가 받지 않음).

## 권한 / 보안

- JWT + StrictRolesGuard('breeder')
- 본인 글 아님 / 비활성 / 미존재 모두 400 동일 — 다른 브리더 소유 정보 누설 방지
- DELETE 는 soft (isActive=false). 다른 도메인이 참조하는 도큐먼트는 보존

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] e2e: 본인 글 PATCH → 200, 응답 petId
- [ ] e2e: 다른 브리더 글 PATCH → 400
- [ ] e2e: status PATCH → 카드 응답 status 갱신
- [ ] e2e: photos 11장 → 400
- [ ] e2e: DELETE 후 GET /me 에서 노출 안 됨
- [ ] e2e: 이미 isActive=false 인 글 DELETE → 400