### PR TITLE
fix(adoption): 즐겨찾기 추가 시 soft-deleted 펫 차단 (#95 후속)

### DIFF
--- a/src/api/adoption/application/ports/adoption-pet-reader.port.ts
+++ b/src/api/adoption/application/ports/adoption-pet-reader.port.ts
@@ -63,7 +63,15 @@ export interface AdoptionPetReaderPort {
     countList(query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId'>): Promise<number>;
     readList(query: AdoptionPetListQuery): Promise<AdoptionPetSnapshot[]>;
     readPopular(petType: AdoptionPetType | undefined, limit: number): Promise<AdoptionPetSnapshot[]>;
+    /**
+     * 펫 단건 조회. isActive=false 인 도큐먼트도 포함 — 즐겨찾기 해제 등 cleanup 경로 용도.
+     */
     readById(petId: string): Promise<AdoptionPetSnapshot | null>;
+    /**
+     * 활성 펫 단건 조회 — isActive=true 만 반환. 즐겨찾기 추가 등 신규 행위 가드용.
+     * soft-deleted 펫에 새 즐겨찾기/조회수가 쌓여 stale state 가 생기지 않도록 한다.
+     */
+    readActiveById(petId: string): Promise<AdoptionPetSnapshot | null>;
     /**
      * 입양 상세용 — base snapshot 에 건강/부모/사육환경 등 추가 필드 포함.
      * isActive=false 항목은 null 을 반환한다.

--- a/src/api/adoption/application/use-cases/add-adoption-pet-favorite.use-case.ts
+++ b/src/api/adoption/application/use-cases/add-adoption-pet-favorite.use-case.ts
@@ -16,7 +16,9 @@ export class AddAdoptionPetFavoriteUseCase {
     ) {}
 
     async execute(adopterId: string, petId: string): Promise<{ added: boolean; favoriteCount: number }> {
-        const pet = await this.petReader.readById(petId);
+        // 활성 펫(isActive=true) 만 즐겨찾기 추가 허용 — soft-deleted 펫에 stale 즐겨찾기 차단.
+        // 기존 즐겨찾기 제거는 RemoveAdoptionPetFavoriteUseCase 가 readById(전체) 로 cleanup 허용.
+        const pet = await this.petReader.readActiveById(petId);
         if (!pet) {
             throw new BadRequestException('해당 동물을 찾을 수 없습니다.');
         }

--- a/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
+++ b/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
@@ -33,6 +33,11 @@ export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
         return item ? this.toSnapshot(item as unknown as AvailablePetDocument) : null;
     }
 
+    async readActiveById(petId: string): Promise<AdoptionPetSnapshot | null> {
+        const item = await this.repository.findActiveById(petId);
+        return item ? this.toSnapshot(item as unknown as AvailablePetDocument) : null;
+    }
+
     async readByIdDetailed(petId: string): Promise<AdoptionPetDetailSnapshot | null> {
         const item = await this.repository.findActiveById(petId);
         return item ? this.toDetailSnapshot(item as unknown as AvailablePetDocument) : null;

--- a/src/api/adoption/test/application/use-cases/add-adoption-pet-favorite.use-case.spec.ts
+++ b/src/api/adoption/test/application/use-cases/add-adoption-pet-favorite.use-case.spec.ts
@@ -4,7 +4,7 @@ import { AddAdoptionPetFavoriteUseCase } from '../../../application/use-cases/ad
 
 describe('AddAdoptionPetFavoriteUseCase', () => {
     const petReader = {
-        readById: jest.fn(),
+        readActiveById: jest.fn(),
     };
     const favoriteWriter = { addAtomic: jest.fn() };
 
@@ -12,12 +12,22 @@ describe('AddAdoptionPetFavoriteUseCase', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        petReader.readById.mockResolvedValue({ id: 'pet-1', favoriteCount: 5 });
+        petReader.readActiveById.mockResolvedValue({ id: 'pet-1', favoriteCount: 5 });
     });
 
-    it('동물이 없으면 BadRequestException', async () => {
-        petReader.readById.mockResolvedValueOnce(null);
+    it('동물이 없으면(비활성 포함) BadRequestException', async () => {
+        // readActiveById 가 null 반환 — 미존재 또는 isActive=false (soft-deleted) 둘 다 동일 처리.
+        petReader.readActiveById.mockResolvedValueOnce(null);
         await expect(useCase.execute('adopter-1', 'pet-x')).rejects.toThrow(BadRequestException);
+        expect(favoriteWriter.addAtomic).not.toHaveBeenCalled();
+    });
+
+    it('soft-deleted(isActive=false) 펫은 readActiveById 가 null 반환 → 추가 거부', async () => {
+        // 즐겨찾기 추가 가드: soft-deleted 펫에 stale 즐겨찾기/카운터가 쌓이지 않도록 readActiveById 사용.
+        petReader.readActiveById.mockResolvedValueOnce(null);
+        await expect(useCase.execute('adopter-1', 'pet-soft-deleted')).rejects.toThrow(
+            '해당 동물을 찾을 수 없습니다.',
+        );
         expect(favoriteWriter.addAtomic).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

#95 가 분양글 soft delete(\`isActive=false\`)를 활성화한 뒤, 즐겨찾기 추가 경로가 \`readById\`(isActive 무시) 로 존재만 확인하던 회귀를 막는다.

- soft-deleted 펫에 새 즐겨찾기 + \`favoriteCount\` 증가가 통과되면 hidden stale state 발생
- 응답 list(\`listMyFavoritedPets\`)는 이미 \`pet.isActive: true\` 필터로 stale 항목 숨김 중 → 새로 추가만 막으면 됨

## 변경

- \`AdoptionPetReaderPort.readActiveById(petId)\` 추가 — \`isActive=true\` 만 반환
- 어댑터가 기존 \`repository.findActiveById\` 로 위임 (신규 쿼리 없음)
- \`AddAdoptionPetFavoriteUseCase\` 가 \`readActiveById\` 사용 — soft-deleted 펫은 400
- \`RemoveAdoptionPetFavoriteUseCase\` 는 \`readById\` 유지 — 기존 stale 즐겨찾기 cleanup 허용 (해제는 항상 가능)
- 단위 테스트 갱신 — soft-deleted 거부 케이스 추가

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] 단위 테스트 통과 (add-adoption-pet-favorite.use-case.spec)
- [ ] e2e: 활성 펫에 POST favorite → 200 (회귀 가드)
- [ ] e2e: soft-deleted 펫에 POST favorite → 400
- [ ] e2e: soft-deleted 펫에 DELETE favorite → 200 (기존 stale 정리 가능)