### PR TITLE
feat(contest): v2 명예의 전당/콘테스트 도메인 신규 구현

### DIFF
--- a/src/api/contest/application/ports/contest-asset-url.port.ts
+++ b/src/api/contest/application/ports/contest-asset-url.port.ts
@@ -1,0 +1,5 @@
+export const CONTEST_ASSET_URL_PORT = Symbol('CONTEST_ASSET_URL_PORT');
+
+export interface ContestAssetUrlPort {
+    generateSignedUrl(fileName: string): Promise<string>;
+}

--- a/src/api/contest/application/ports/contest-reader.port.ts
+++ b/src/api/contest/application/ports/contest-reader.port.ts
@@ -1,0 +1,54 @@
+export const CONTEST_READER_PORT = Symbol('CONTEST_READER_PORT');
+
+export interface ContestSnapshot {
+    id: string;
+    title: string;
+    description: string;
+    benefitText: string;
+    startDate: Date;
+    endDate: Date;
+    status: 'active' | 'ended';
+    participantCount: number;
+    createdAt: Date;
+}
+
+export interface ContestEntrySnapshot {
+    id: string;
+    contestId: string;
+    userId: string;
+    userDisplayName: string;
+    userProfileImageFileName: string | null;
+    photoFileName: string;
+    description: string;
+    voteCount: number;
+    rank: number | null;
+    createdAt: Date;
+}
+
+export interface ContestReaderPort {
+    /** 현재 active 콘테스트 조회 */
+    findActive(): Promise<ContestSnapshot | null>;
+
+    /** 가장 최근 ended 콘테스트 조회 (저번주 랭킹용) */
+    findLatestEnded(): Promise<ContestSnapshot | null>;
+
+    /** 모든 ended 콘테스트 (명예의 전당 목록용, 최신순) */
+    findAllEnded(query: { page: number; limit: number }): Promise<ContestSnapshot[]>;
+    countAllEnded(): Promise<number>;
+
+    /** 특정 콘테스트 상위 N 개 항목 (voteCount 내림차순) */
+    findTopEntries(contestId: string, limit: number): Promise<ContestEntrySnapshot[]>;
+
+    /** 항목 페이지네이션 (voteCount 내림차순) */
+    findEntries(contestId: string, query: { page: number; limit: number }): Promise<ContestEntrySnapshot[]>;
+    countEntries(contestId: string): Promise<number>;
+
+    /** 유저의 콘테스트 항목 조회 */
+    findEntryByUserId(contestId: string, userId: string): Promise<ContestEntrySnapshot | null>;
+
+    /** 항목 단건 조회 */
+    findEntryById(entryId: string): Promise<ContestEntrySnapshot | null>;
+
+    /** 유저가 콘테스트에서 투표한 entryId 반환 (없으면 null) */
+    findVotedEntryId(contestId: string, voterId: string): Promise<string | null>;
+}

--- a/src/api/contest/application/ports/contest-user-info.port.ts
+++ b/src/api/contest/application/ports/contest-user-info.port.ts
@@ -1,0 +1,10 @@
+export const CONTEST_USER_INFO_PORT = Symbol('CONTEST_USER_INFO_PORT');
+
+export interface ContestUserInfoSnapshot {
+    displayName: string;
+    profileImageFileName: string | null;
+}
+
+export interface ContestUserInfoPort {
+    readUserInfo(userId: string, role: 'adopter' | 'breeder'): Promise<ContestUserInfoSnapshot | null>;
+}

--- a/src/api/contest/application/ports/contest-writer.port.ts
+++ b/src/api/contest/application/ports/contest-writer.port.ts
@@ -1,0 +1,16 @@
+export const CONTEST_WRITER_PORT = Symbol('CONTEST_WRITER_PORT');
+
+export interface CreateContestEntryData {
+    contestId: string;
+    userId: string;
+    userDisplayName: string;
+    userProfileImageFileName: string | null;
+    photoFileName: string;
+    description: string;
+}
+
+export interface ContestWriterPort {
+    createEntry(data: CreateContestEntryData): Promise<string>;
+    incrementParticipantCount(contestId: string): Promise<void>;
+    vote(data: { contestId: string; entryId: string; voterId: string }): Promise<number>;
+}

--- a/src/api/contest/application/types/contest-result.type.ts
+++ b/src/api/contest/application/types/contest-result.type.ts
@@ -1,0 +1,67 @@
+export interface ContestEntryItem {
+    id: string;
+    userId: string;
+    userDisplayName: string;
+    userProfileImageUrl: string | null;
+    photoUrl: string;
+    description: string;
+    voteCount: number;
+    rank: number | null;
+    hasVoted: boolean;
+    isMyEntry: boolean;
+    createdAt: Date;
+}
+
+export interface ContestInfo {
+    id: string;
+    title: string;
+    description: string;
+    benefitText: string;
+    startDate: Date;
+    endDate: Date;
+    status: 'active' | 'ended';
+    participantCount: number;
+}
+
+export interface GetCurrentContestResult {
+    contest: ContestInfo;
+    ranking: ContestEntryItem[];
+    myVotedEntryId: string | null;
+    hasEntry: boolean;
+}
+
+export interface GetContestEntriesResult {
+    items: ContestEntryItem[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
+export interface GetPreviousRankingResult {
+    contest: ContestInfo;
+    ranking: ContestEntryItem[];
+}
+
+export interface GetHallOfFameResult {
+    items: HallOfFameItem[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
+export interface HallOfFameItem {
+    contestId: string;
+    contestTitle: string;
+    startDate: Date;
+    endDate: Date;
+    winner: ContestEntryItem;
+}
+
+export interface SubmitContestEntryResult {
+    entryId: string;
+}
+
+export interface VoteContestEntryResult {
+    entryId: string;
+    newVoteCount: number;
+}

--- a/src/api/contest/application/use-cases/get-contest-entries.use-case.ts
+++ b/src/api/contest/application/use-cases/get-contest-entries.use-case.ts
@@ -1,0 +1,77 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestEntrySnapshot, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { ContestEntryItem, GetContestEntriesResult } from '../types/contest-result.type';
+
+export interface GetContestEntriesCommand {
+    page: number;
+    limit: number;
+    userId?: string;
+}
+
+@Injectable()
+export class GetContestEntriesUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(command: GetContestEntriesCommand): Promise<GetContestEntriesResult> {
+        this.logger.logStart('getContestEntries', '콘테스트 항목 목록 조회');
+
+        const contest = await this.reader.findActive();
+        if (!contest) {
+            throw new BadRequestException('현재 진행 중인 콘테스트가 없습니다.');
+        }
+
+        const { page, limit, userId } = command;
+
+        const [entries, total, votedEntryId] = await Promise.all([
+            this.reader.findEntries(contest.id, { page, limit }),
+            this.reader.countEntries(contest.id),
+            userId ? this.reader.findVotedEntryId(contest.id, userId) : Promise.resolve<string | null>(null),
+        ]);
+
+        const items = await this.resolveEntries(entries, userId, votedEntryId);
+
+        this.logger.logSuccess('getContestEntries', '콘테스트 항목 목록 조회 완료', { count: items.length });
+
+        return { items, total, page, limit };
+    }
+
+    private async resolveEntries(
+        entries: ContestEntrySnapshot[],
+        userId: string | undefined,
+        votedEntryId: string | null,
+    ): Promise<ContestEntryItem[]> {
+        return Promise.all(
+            entries.map(async (entry) => {
+                const [photoUrl, profileImageUrl] = await Promise.all([
+                    this.assetUrl.generateSignedUrl(entry.photoFileName),
+                    entry.userProfileImageFileName
+                        ? this.assetUrl.generateSignedUrl(entry.userProfileImageFileName)
+                        : Promise.resolve<string | null>(null),
+                ]);
+
+                return {
+                    id: entry.id,
+                    userId: entry.userId,
+                    userDisplayName: entry.userDisplayName,
+                    userProfileImageUrl: profileImageUrl,
+                    photoUrl,
+                    description: entry.description,
+                    voteCount: entry.voteCount,
+                    rank: entry.rank,
+                    hasVoted: votedEntryId === entry.id,
+                    isMyEntry: userId === entry.userId,
+                    createdAt: entry.createdAt,
+                };
+            }),
+        );
+    }
+}

--- a/src/api/contest/application/use-cases/get-current-contest.use-case.ts
+++ b/src/api/contest/application/use-cases/get-current-contest.use-case.ts
@@ -1,0 +1,85 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestEntrySnapshot, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { ContestEntryItem, ContestInfo, GetCurrentContestResult } from '../types/contest-result.type';
+
+@Injectable()
+export class GetCurrentContestUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(userId?: string): Promise<GetCurrentContestResult | null> {
+        this.logger.logStart('getCurrentContest', '현재 콘테스트 조회');
+
+        const contest = await this.reader.findActive();
+        if (!contest) {
+            return null;
+        }
+
+        const [topEntries, votedEntryId, myEntry] = await Promise.all([
+            this.reader.findTopEntries(contest.id, 3),
+            userId ? this.reader.findVotedEntryId(contest.id, userId) : Promise.resolve<string | null>(null),
+            userId ? this.reader.findEntryByUserId(contest.id, userId) : Promise.resolve(null),
+        ]);
+
+        const ranking = await this.resolveEntries(topEntries, userId, votedEntryId);
+
+        const info: ContestInfo = {
+            id: contest.id,
+            title: contest.title,
+            description: contest.description,
+            benefitText: contest.benefitText,
+            startDate: contest.startDate,
+            endDate: contest.endDate,
+            status: contest.status,
+            participantCount: contest.participantCount,
+        };
+
+        this.logger.logSuccess('getCurrentContest', '현재 콘테스트 조회 완료', { contestId: contest.id });
+
+        return {
+            contest: info,
+            ranking,
+            myVotedEntryId: votedEntryId,
+            hasEntry: !!myEntry,
+        };
+    }
+
+    private async resolveEntries(
+        entries: ContestEntrySnapshot[],
+        userId: string | undefined,
+        votedEntryId: string | null,
+    ): Promise<ContestEntryItem[]> {
+        return Promise.all(
+            entries.map(async (entry, index) => {
+                const [photoUrl, profileImageUrl] = await Promise.all([
+                    this.assetUrl.generateSignedUrl(entry.photoFileName),
+                    entry.userProfileImageFileName
+                        ? this.assetUrl.generateSignedUrl(entry.userProfileImageFileName)
+                        : Promise.resolve<string | null>(null),
+                ]);
+
+                return {
+                    id: entry.id,
+                    userId: entry.userId,
+                    userDisplayName: entry.userDisplayName,
+                    userProfileImageUrl: profileImageUrl,
+                    photoUrl,
+                    description: entry.description,
+                    voteCount: entry.voteCount,
+                    rank: entry.rank ?? index + 1,
+                    hasVoted: votedEntryId === entry.id,
+                    isMyEntry: userId === entry.userId,
+                    createdAt: entry.createdAt,
+                };
+            }),
+        );
+    }
+}

--- a/src/api/contest/application/use-cases/get-hall-of-fame.use-case.ts
+++ b/src/api/contest/application/use-cases/get-hall-of-fame.use-case.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { GetHallOfFameResult, HallOfFameItem } from '../types/contest-result.type';
+
+export interface GetHallOfFameCommand {
+    page: number;
+    limit: number;
+}
+
+@Injectable()
+export class GetHallOfFameUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(command: GetHallOfFameCommand): Promise<GetHallOfFameResult> {
+        this.logger.logStart('getHallOfFame', '명예의 전당 조회');
+
+        const { page, limit } = command;
+        const [contests, total] = await Promise.all([
+            this.reader.findAllEnded({ page, limit }),
+            this.reader.countAllEnded(),
+        ]);
+
+        const items: HallOfFameItem[] = [];
+
+        for (const contest of contests) {
+            const topEntries = await this.reader.findTopEntries(contest.id, 1);
+            if (topEntries.length === 0) continue;
+
+            const winner = topEntries[0];
+            const [photoUrl, profileImageUrl] = await Promise.all([
+                this.assetUrl.generateSignedUrl(winner.photoFileName),
+                winner.userProfileImageFileName
+                    ? this.assetUrl.generateSignedUrl(winner.userProfileImageFileName)
+                    : Promise.resolve<string | null>(null),
+            ]);
+
+            items.push({
+                contestId: contest.id,
+                contestTitle: contest.title,
+                startDate: contest.startDate,
+                endDate: contest.endDate,
+                winner: {
+                    id: winner.id,
+                    userId: winner.userId,
+                    userDisplayName: winner.userDisplayName,
+                    userProfileImageUrl: profileImageUrl,
+                    photoUrl,
+                    description: winner.description,
+                    voteCount: winner.voteCount,
+                    rank: winner.rank ?? 1,
+                    hasVoted: false,
+                    isMyEntry: false,
+                    createdAt: winner.createdAt,
+                },
+            });
+        }
+
+        this.logger.logSuccess('getHallOfFame', '명예의 전당 조회 완료', { count: items.length });
+
+        return { items, total, page, limit };
+    }
+}

--- a/src/api/contest/application/use-cases/get-my-contest-entry.use-case.ts
+++ b/src/api/contest/application/use-cases/get-my-contest-entry.use-case.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { ContestEntryItem } from '../types/contest-result.type';
+
+@Injectable()
+export class GetMyContestEntryUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(userId: string): Promise<ContestEntryItem | null> {
+        this.logger.logStart('getMyContestEntry', '나의 콘테스트 참여 항목 조회', { userId });
+
+        const contest = await this.reader.findActive();
+        if (!contest) {
+            return null;
+        }
+
+        const entry = await this.reader.findEntryByUserId(contest.id, userId);
+        if (!entry) {
+            return null;
+        }
+
+        const votedEntryId = await this.reader.findVotedEntryId(contest.id, userId);
+
+        const [photoUrl, profileImageUrl] = await Promise.all([
+            this.assetUrl.generateSignedUrl(entry.photoFileName),
+            entry.userProfileImageFileName
+                ? this.assetUrl.generateSignedUrl(entry.userProfileImageFileName)
+                : Promise.resolve<string | null>(null),
+        ]);
+
+        this.logger.logSuccess('getMyContestEntry', '나의 콘테스트 참여 항목 조회 완료');
+
+        return {
+            id: entry.id,
+            userId: entry.userId,
+            userDisplayName: entry.userDisplayName,
+            userProfileImageUrl: profileImageUrl,
+            photoUrl,
+            description: entry.description,
+            voteCount: entry.voteCount,
+            rank: entry.rank,
+            hasVoted: votedEntryId !== null,
+            isMyEntry: true,
+            createdAt: entry.createdAt,
+        };
+    }
+}

--- a/src/api/contest/application/use-cases/get-previous-ranking.use-case.ts
+++ b/src/api/contest/application/use-cases/get-previous-ranking.use-case.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestEntrySnapshot, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { ContestEntryItem, ContestInfo, GetPreviousRankingResult } from '../types/contest-result.type';
+
+@Injectable()
+export class GetPreviousRankingUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(): Promise<GetPreviousRankingResult | null> {
+        this.logger.logStart('getPreviousRanking', '저번 콘테스트 랭킹 조회');
+
+        const contest = await this.reader.findLatestEnded();
+        if (!contest) {
+            return null;
+        }
+
+        const entries = await this.reader.findTopEntries(contest.id, 3);
+        const ranking = await this.resolveEntries(entries);
+
+        const info: ContestInfo = {
+            id: contest.id,
+            title: contest.title,
+            description: contest.description,
+            benefitText: contest.benefitText,
+            startDate: contest.startDate,
+            endDate: contest.endDate,
+            status: contest.status,
+            participantCount: contest.participantCount,
+        };
+
+        this.logger.logSuccess('getPreviousRanking', '저번 콘테스트 랭킹 조회 완료', { contestId: contest.id });
+
+        return { contest: info, ranking };
+    }
+
+    private async resolveEntries(entries: ContestEntrySnapshot[]): Promise<ContestEntryItem[]> {
+        return Promise.all(
+            entries.map(async (entry, index) => {
+                const [photoUrl, profileImageUrl] = await Promise.all([
+                    this.assetUrl.generateSignedUrl(entry.photoFileName),
+                    entry.userProfileImageFileName
+                        ? this.assetUrl.generateSignedUrl(entry.userProfileImageFileName)
+                        : Promise.resolve<string | null>(null),
+                ]);
+
+                return {
+                    id: entry.id,
+                    userId: entry.userId,
+                    userDisplayName: entry.userDisplayName,
+                    userProfileImageUrl: profileImageUrl,
+                    photoUrl,
+                    description: entry.description,
+                    voteCount: entry.voteCount,
+                    rank: entry.rank ?? index + 1,
+                    hasVoted: false,
+                    isMyEntry: false,
+                    createdAt: entry.createdAt,
+                };
+            }),
+        );
+    }
+}

--- a/src/api/contest/application/use-cases/submit-contest-entry.use-case.ts
+++ b/src/api/contest/application/use-cases/submit-contest-entry.use-case.ts
@@ -1,0 +1,61 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_READER_PORT, type ContestReaderPort } from '../ports/contest-reader.port';
+import { CONTEST_USER_INFO_PORT, type ContestUserInfoPort } from '../ports/contest-user-info.port';
+import { CONTEST_WRITER_PORT, type ContestWriterPort } from '../ports/contest-writer.port';
+import type { SubmitContestEntryResult } from '../types/contest-result.type';
+
+export interface SubmitContestEntryCommand {
+    userId: string;
+    role: 'adopter' | 'breeder';
+    photoFileName: string;
+    description: string;
+}
+
+@Injectable()
+export class SubmitContestEntryUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_WRITER_PORT)
+        private readonly writer: ContestWriterPort,
+        @Inject(CONTEST_USER_INFO_PORT)
+        private readonly userInfo: ContestUserInfoPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(command: SubmitContestEntryCommand): Promise<SubmitContestEntryResult> {
+        this.logger.logStart('submitContestEntry', '콘테스트 참여 시작', { userId: command.userId });
+
+        const contest = await this.reader.findActive();
+        if (!contest) {
+            throw new BadRequestException('현재 진행 중인 콘테스트가 없습니다.');
+        }
+
+        const existing = await this.reader.findEntryByUserId(contest.id, command.userId);
+        if (existing) {
+            throw new BadRequestException('이미 이번 콘테스트에 참여하셨습니다.');
+        }
+
+        const userSnapshot = await this.userInfo.readUserInfo(command.userId, command.role);
+        if (!userSnapshot) {
+            throw new BadRequestException('사용자 정보를 찾을 수 없습니다.');
+        }
+
+        const entryId = await this.writer.createEntry({
+            contestId: contest.id,
+            userId: command.userId,
+            userDisplayName: userSnapshot.displayName,
+            userProfileImageFileName: userSnapshot.profileImageFileName,
+            photoFileName: command.photoFileName,
+            description: command.description,
+        });
+
+        await this.writer.incrementParticipantCount(contest.id);
+
+        this.logger.logSuccess('submitContestEntry', '콘테스트 참여 완료', { entryId });
+
+        return { entryId };
+    }
+}

--- a/src/api/contest/application/use-cases/vote-contest-entry.use-case.ts
+++ b/src/api/contest/application/use-cases/vote-contest-entry.use-case.ts
@@ -1,0 +1,45 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_READER_PORT, type ContestReaderPort } from '../ports/contest-reader.port';
+import { CONTEST_WRITER_PORT, type ContestWriterPort } from '../ports/contest-writer.port';
+import type { VoteContestEntryResult } from '../types/contest-result.type';
+
+@Injectable()
+export class VoteContestEntryUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_WRITER_PORT)
+        private readonly writer: ContestWriterPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(entryId: string, voterId: string): Promise<VoteContestEntryResult> {
+        this.logger.logStart('voteContestEntry', '콘테스트 투표 시작', { entryId, voterId });
+
+        const entry = await this.reader.findEntryById(entryId);
+        if (!entry) {
+            throw new BadRequestException('해당 콘테스트 항목을 찾을 수 없습니다.');
+        }
+
+        if (entry.userId === voterId) {
+            throw new BadRequestException('자신의 항목에는 투표할 수 없습니다.');
+        }
+
+        const existingVote = await this.reader.findVotedEntryId(entry.contestId, voterId);
+        if (existingVote) {
+            throw new BadRequestException('이번 콘테스트에서 이미 투표하셨습니다.');
+        }
+
+        const newVoteCount = await this.writer.vote({
+            contestId: entry.contestId,
+            entryId,
+            voterId,
+        });
+
+        this.logger.logSuccess('voteContestEntry', '콘테스트 투표 완료', { entryId, newVoteCount });
+
+        return { entryId, newVoteCount };
+    }
+}

--- a/src/api/contest/contest.module-definition.ts
+++ b/src/api/contest/contest.module-definition.ts
@@ -1,0 +1,79 @@
+import { MongooseModule } from '@nestjs/mongoose';
+
+import { StorageModule } from '../../common/storage/storage.module';
+import { Adopter, AdopterSchema } from '../../schema/adopter.schema';
+import { Breeder, BreederSchema } from '../../schema/breeder.schema';
+import { Contest, ContestSchema } from '../../schema/contest.schema';
+import { ContestEntry, ContestEntrySchema } from '../../schema/contest-entry.schema';
+import { ContestVote, ContestVoteSchema } from '../../schema/contest-vote.schema';
+
+import { CONTEST_ASSET_URL_PORT } from './application/ports/contest-asset-url.port';
+import { CONTEST_READER_PORT } from './application/ports/contest-reader.port';
+import { CONTEST_USER_INFO_PORT } from './application/ports/contest-user-info.port';
+import { CONTEST_WRITER_PORT } from './application/ports/contest-writer.port';
+import { GetCurrentContestUseCase } from './application/use-cases/get-current-contest.use-case';
+import { GetContestEntriesUseCase } from './application/use-cases/get-contest-entries.use-case';
+import { SubmitContestEntryUseCase } from './application/use-cases/submit-contest-entry.use-case';
+import { VoteContestEntryUseCase } from './application/use-cases/vote-contest-entry.use-case';
+import { GetMyContestEntryUseCase } from './application/use-cases/get-my-contest-entry.use-case';
+import { GetPreviousRankingUseCase } from './application/use-cases/get-previous-ranking.use-case';
+import { GetHallOfFameUseCase } from './application/use-cases/get-hall-of-fame.use-case';
+import { ContestCurrentController } from './controller/contest-current.controller';
+import { ContestEntriesController } from './controller/contest-entries.controller';
+import { ContestEntrySubmitController } from './controller/contest-entry-submit.controller';
+import { ContestHallOfFameController } from './controller/contest-hall-of-fame.controller';
+import { ContestMeController } from './controller/contest-me.controller';
+import { ContestPreviousRankingController } from './controller/contest-previous-ranking.controller';
+import { ContestVoteController } from './controller/contest-vote.controller';
+import { ContestAssetUrlStorageAdapter } from './infrastructure/contest-asset-url-storage.adapter';
+import { ContestReaderMongooseAdapter } from './infrastructure/contest-reader-mongoose.adapter';
+import { ContestUserInfoMongooseAdapter } from './infrastructure/contest-user-info-mongoose.adapter';
+import { ContestWriterMongooseAdapter } from './infrastructure/contest-writer-mongoose.adapter';
+import { ContestRepository } from './repository/contest.repository';
+
+const SCHEMA_IMPORTS = MongooseModule.forFeature([
+    { name: Contest.name, schema: ContestSchema },
+    { name: ContestEntry.name, schema: ContestEntrySchema },
+    { name: ContestVote.name, schema: ContestVoteSchema },
+    { name: Adopter.name, schema: AdopterSchema },
+    { name: Breeder.name, schema: BreederSchema },
+]);
+
+export const CONTEST_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule];
+
+export const CONTEST_MODULE_CONTROLLERS = [
+    ContestCurrentController,
+    ContestEntriesController,
+    ContestEntrySubmitController,
+    ContestVoteController,
+    ContestMeController,
+    ContestPreviousRankingController,
+    ContestHallOfFameController,
+];
+
+const USE_CASE_PROVIDERS = [
+    GetCurrentContestUseCase,
+    GetContestEntriesUseCase,
+    SubmitContestEntryUseCase,
+    VoteContestEntryUseCase,
+    GetMyContestEntryUseCase,
+    GetPreviousRankingUseCase,
+    GetHallOfFameUseCase,
+];
+
+const INFRASTRUCTURE_PROVIDERS = [
+    ContestRepository,
+    ContestReaderMongooseAdapter,
+    ContestWriterMongooseAdapter,
+    ContestAssetUrlStorageAdapter,
+    ContestUserInfoMongooseAdapter,
+];
+
+const PORT_BINDINGS = [
+    { provide: CONTEST_READER_PORT, useExisting: ContestReaderMongooseAdapter },
+    { provide: CONTEST_WRITER_PORT, useExisting: ContestWriterMongooseAdapter },
+    { provide: CONTEST_ASSET_URL_PORT, useExisting: ContestAssetUrlStorageAdapter },
+    { provide: CONTEST_USER_INFO_PORT, useExisting: ContestUserInfoMongooseAdapter },
+];
+
+export const CONTEST_MODULE_PROVIDERS = [...USE_CASE_PROVIDERS, ...INFRASTRUCTURE_PROVIDERS, ...PORT_BINDINGS];

--- a/src/api/contest/contest.module.ts
+++ b/src/api/contest/contest.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { CONTEST_MODULE_CONTROLLERS, CONTEST_MODULE_IMPORTS, CONTEST_MODULE_PROVIDERS } from './contest.module-definition';
+
+/**
+ * 명예의 전당 / 콘테스트 모듈 (v2)
+ * /v2/contest 라우트 — 주간 사진 콘테스트 참여·투표·랭킹·명예의 전당 조회
+ */
+@Module({
+    imports: CONTEST_MODULE_IMPORTS,
+    controllers: CONTEST_MODULE_CONTROLLERS,
+    providers: CONTEST_MODULE_PROVIDERS,
+})
+export class ContestModule {}

--- a/src/api/contest/controller/contest-current.controller.ts
+++ b/src/api/contest/controller/contest-current.controller.ts
@@ -1,0 +1,23 @@
+import { Get } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetCurrentContestUseCase } from '../application/use-cases/get-current-contest.use-case';
+import { ContestPublicController } from '../decorator/contest-controller.decorator';
+import { ApiGetCurrentContestEndpoint } from '../swagger';
+
+/**
+ * 현재 콘테스트 + 실시간 1~3위 랭킹 (Figma 716:65272, 315:5985).
+ * GET v2/contest/current
+ */
+@ContestPublicController()
+export class ContestCurrentController {
+    constructor(private readonly getCurrentContestUseCase: GetCurrentContestUseCase) {}
+
+    @Get('current')
+    @ApiGetCurrentContestEndpoint()
+    async getCurrent(@CurrentUser('userId') userId?: string): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getCurrentContestUseCase.execute(userId);
+        return ApiResponseDto.success(result, '현재 콘테스트 조회 완료');
+    }
+}

--- a/src/api/contest/controller/contest-entries.controller.ts
+++ b/src/api/contest/controller/contest-entries.controller.ts
@@ -1,0 +1,31 @@
+import { Get, Query } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetContestEntriesUseCase } from '../application/use-cases/get-contest-entries.use-case';
+import { ContestPublicController } from '../decorator/contest-controller.decorator';
+import { ApiGetContestEntriesEndpoint } from '../swagger';
+
+/**
+ * 투표 항목 목록 (Figma 315:5985 투표하기 그리드).
+ * GET v2/contest/entries?page=1&limit=9
+ */
+@ContestPublicController()
+export class ContestEntriesController {
+    constructor(private readonly getContestEntriesUseCase: GetContestEntriesUseCase) {}
+
+    @Get('entries')
+    @ApiGetContestEntriesEndpoint()
+    async getEntries(
+        @Query('page') page = 1,
+        @Query('limit') limit = 9,
+        @CurrentUser('userId') userId?: string,
+    ): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getContestEntriesUseCase.execute({
+            page: Number(page),
+            limit: Number(limit),
+            userId,
+        });
+        return ApiResponseDto.success(result, '콘테스트 항목 조회 완료');
+    }
+}

--- a/src/api/contest/controller/contest-entry-submit.controller.ts
+++ b/src/api/contest/controller/contest-entry-submit.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Post } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { SubmitContestEntryUseCase } from '../application/use-cases/submit-contest-entry.use-case';
+import { ContestProtectedController } from '../decorator/contest-controller.decorator';
+import { SubmitContestEntryRequestDto } from '../dto/request/submit-contest-entry-request.dto';
+import { ApiSubmitContestEntryEndpoint } from '../swagger';
+
+/**
+ * 콘테스트 참여 (Figma 350:2356 콘테스트 참여 모달).
+ * POST v2/contest/entry
+ */
+@ContestProtectedController()
+export class ContestEntrySubmitController {
+    constructor(private readonly submitContestEntryUseCase: SubmitContestEntryUseCase) {}
+
+    @Post('entry')
+    @ApiSubmitContestEntryEndpoint()
+    async submit(
+        @CurrentUser('userId') userId: string,
+        @CurrentUser('role') role: string,
+        @Body() dto: SubmitContestEntryRequestDto,
+    ): Promise<ApiResponseDto<unknown>> {
+        if (role !== 'adopter' && role !== 'breeder') {
+            throw new Error('지원하지 않는 역할입니다.');
+        }
+        const result = await this.submitContestEntryUseCase.execute({
+            userId,
+            role,
+            photoFileName: dto.photoFileName,
+            description: dto.description,
+        });
+        return ApiResponseDto.success(result, '콘테스트 참여가 완료되었습니다.');
+    }
+}

--- a/src/api/contest/controller/contest-hall-of-fame.controller.ts
+++ b/src/api/contest/controller/contest-hall-of-fame.controller.ts
@@ -1,0 +1,22 @@
+import { Get, Query } from '@nestjs/common';
+
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetHallOfFameUseCase } from '../application/use-cases/get-hall-of-fame.use-case';
+import { ContestPublicController } from '../decorator/contest-controller.decorator';
+import { ApiGetHallOfFameEndpoint } from '../swagger';
+
+/**
+ * 역대 명예의 전당 목록 (Figma 715:62770).
+ * GET v2/contest/hall-of-fame?page=1&limit=10
+ */
+@ContestPublicController()
+export class ContestHallOfFameController {
+    constructor(private readonly getHallOfFameUseCase: GetHallOfFameUseCase) {}
+
+    @Get('hall-of-fame')
+    @ApiGetHallOfFameEndpoint()
+    async getHallOfFame(@Query('page') page = 1, @Query('limit') limit = 10): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getHallOfFameUseCase.execute({ page: Number(page), limit: Number(limit) });
+        return ApiResponseDto.success(result, '명예의 전당 조회 완료');
+    }
+}

--- a/src/api/contest/controller/contest-me.controller.ts
+++ b/src/api/contest/controller/contest-me.controller.ts
@@ -1,0 +1,23 @@
+import { Get } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetMyContestEntryUseCase } from '../application/use-cases/get-my-contest-entry.use-case';
+import { ContestProtectedController } from '../decorator/contest-controller.decorator';
+import { ApiGetMyContestEntryEndpoint } from '../swagger';
+
+/**
+ * 나의 참여 항목 (Figma 716:65272 나의 참여 보기).
+ * GET v2/contest/me/entry
+ */
+@ContestProtectedController()
+export class ContestMeController {
+    constructor(private readonly getMyContestEntryUseCase: GetMyContestEntryUseCase) {}
+
+    @Get('me/entry')
+    @ApiGetMyContestEntryEndpoint()
+    async getMyEntry(@CurrentUser('userId') userId: string): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getMyContestEntryUseCase.execute(userId);
+        return ApiResponseDto.success(result, '나의 참여 항목 조회 완료');
+    }
+}

--- a/src/api/contest/controller/contest-previous-ranking.controller.ts
+++ b/src/api/contest/controller/contest-previous-ranking.controller.ts
@@ -1,0 +1,22 @@
+import { Get } from '@nestjs/common';
+
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetPreviousRankingUseCase } from '../application/use-cases/get-previous-ranking.use-case';
+import { ContestPublicController } from '../decorator/contest-controller.decorator';
+import { ApiGetPreviousRankingEndpoint } from '../swagger';
+
+/**
+ * 저번 콘테스트 1~3위 (Figma 716:65272 저번주 랭킹 섹션).
+ * GET v2/contest/previous-ranking
+ */
+@ContestPublicController()
+export class ContestPreviousRankingController {
+    constructor(private readonly getPreviousRankingUseCase: GetPreviousRankingUseCase) {}
+
+    @Get('previous-ranking')
+    @ApiGetPreviousRankingEndpoint()
+    async getPreviousRanking(): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getPreviousRankingUseCase.execute();
+        return ApiResponseDto.success(result, '저번 콘테스트 랭킹 조회 완료');
+    }
+}

--- a/src/api/contest/controller/contest-vote.controller.ts
+++ b/src/api/contest/controller/contest-vote.controller.ts
@@ -1,0 +1,27 @@
+import { Param, Post } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { MongoObjectIdPipe } from '../../../common/pipe/mongo-object-id.pipe';
+import { VoteContestEntryUseCase } from '../application/use-cases/vote-contest-entry.use-case';
+import { ContestProtectedController } from '../decorator/contest-controller.decorator';
+import { ApiVoteContestEntryEndpoint } from '../swagger';
+
+/**
+ * 콘테스트 항목 투표 (Figma 315:5985 투표하기 버튼).
+ * POST v2/contest/vote/:entryId
+ */
+@ContestProtectedController()
+export class ContestVoteController {
+    constructor(private readonly voteContestEntryUseCase: VoteContestEntryUseCase) {}
+
+    @Post('vote/:entryId')
+    @ApiVoteContestEntryEndpoint()
+    async vote(
+        @Param('entryId', new MongoObjectIdPipe('항목')) entryId: string,
+        @CurrentUser('userId') userId: string,
+    ): Promise<ApiResponseDto<unknown>> {
+        const result = await this.voteContestEntryUseCase.execute(entryId, userId);
+        return ApiResponseDto.success(result, '투표가 완료되었습니다.');
+    }
+}

--- a/src/api/contest/decorator/contest-controller.decorator.ts
+++ b/src/api/contest/decorator/contest-controller.decorator.ts
@@ -1,0 +1,12 @@
+import { Controller, UseGuards, applyDecorators } from '@nestjs/common';
+
+import { JwtAuthGuard } from '../../../common/guard/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../../../common/guard/optional-jwt-auth.guard';
+
+export function ContestPublicController() {
+    return applyDecorators(Controller('v2/contest'), UseGuards(OptionalJwtAuthGuard));
+}
+
+export function ContestProtectedController() {
+    return applyDecorators(Controller('v2/contest'), UseGuards(JwtAuthGuard));
+}

--- a/src/api/contest/dto/request/submit-contest-entry-request.dto.ts
+++ b/src/api/contest/dto/request/submit-contest-entry-request.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class SubmitContestEntryRequestDto {
+    @ApiProperty({ description: 'S3에 업로드된 사진 파일명', example: 'contest/uuid-photo.jpg' })
+    @IsString()
+    @IsNotEmpty()
+    photoFileName: string;
+
+    @ApiProperty({ description: '한 줄 소개 (최대 200자)', example: '이번달 가장 귀여운 레오파드 게코입니다!' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(200)
+    description: string;
+}

--- a/src/api/contest/dto/response/contest-current-response.dto.ts
+++ b/src/api/contest/dto/response/contest-current-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ContestEntryDto, ContestInfoDto } from './contest-entry.dto';
+
+export class ContestCurrentResponseDto {
+    @ApiProperty({ type: ContestInfoDto })
+    contest: ContestInfoDto;
+
+    @ApiProperty({ description: '현재 실시간 1~3위', type: [ContestEntryDto] })
+    ranking: ContestEntryDto[];
+
+    @ApiProperty({ description: '내가 투표한 항목 ID (미로그인/미투표 시 null)', nullable: true })
+    myVotedEntryId: string | null;
+
+    @ApiProperty({ description: '내가 이미 참여했는지 여부' })
+    hasEntry: boolean;
+}

--- a/src/api/contest/dto/response/contest-entries-response.dto.ts
+++ b/src/api/contest/dto/response/contest-entries-response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ContestEntryDto } from './contest-entry.dto';
+
+export class ContestEntriesResponseDto {
+    @ApiProperty({ type: [ContestEntryDto] })
+    items: ContestEntryDto[];
+
+    @ApiProperty()
+    total: number;
+
+    @ApiProperty()
+    page: number;
+
+    @ApiProperty()
+    limit: number;
+}
+
+export class ContestSubmitResponseDto {
+    @ApiProperty({ description: '생성된 항목 ID' })
+    entryId: string;
+}
+
+export class ContestVoteResponseDto {
+    @ApiProperty({ description: '투표된 항목 ID' })
+    entryId: string;
+
+    @ApiProperty({ description: '투표 후 총 투표 수' })
+    newVoteCount: number;
+}

--- a/src/api/contest/dto/response/contest-entry.dto.ts
+++ b/src/api/contest/dto/response/contest-entry.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ContestEntryDto {
+    @ApiProperty({ description: '항목 ID' })
+    id: string;
+
+    @ApiProperty({ description: '제출자 유저 ID' })
+    userId: string;
+
+    @ApiProperty({ description: '제출자 표시명' })
+    userDisplayName: string;
+
+    @ApiProperty({ description: '제출자 프로필 이미지 URL', nullable: true, required: false })
+    userProfileImageUrl: string | null;
+
+    @ApiProperty({ description: '사진 signed URL' })
+    photoUrl: string;
+
+    @ApiProperty({ description: '설명' })
+    description: string;
+
+    @ApiProperty({ description: '받은 투표 수' })
+    voteCount: number;
+
+    @ApiProperty({ description: '순위 (1~3, null = 미집계)', nullable: true, required: false })
+    rank: number | null;
+
+    @ApiProperty({ description: '현재 유저가 이 항목에 투표했는지 여부' })
+    hasVoted: boolean;
+
+    @ApiProperty({ description: '현재 유저의 항목인지 여부' })
+    isMyEntry: boolean;
+
+    @ApiProperty({ description: '제출 시각 ISO' })
+    createdAt: string;
+}
+
+export class ContestInfoDto {
+    @ApiProperty({ description: '콘테스트 ID' })
+    id: string;
+
+    @ApiProperty({ description: '콘테스트 제목', example: '이번달 땅예의 전당 주인공이 되어보세요!' })
+    title: string;
+
+    @ApiProperty({ description: '콘테스트 설명' })
+    description: string;
+
+    @ApiProperty({ description: '참여 혜택 안내 문구' })
+    benefitText: string;
+
+    @ApiProperty({ description: '시작일 ISO' })
+    startDate: string;
+
+    @ApiProperty({ description: '종료일 ISO' })
+    endDate: string;
+
+    @ApiProperty({ description: '상태', enum: ['active', 'ended'] })
+    status: string;
+
+    @ApiProperty({ description: '참여자 수' })
+    participantCount: number;
+}

--- a/src/api/contest/dto/response/contest-hall-of-fame-response.dto.ts
+++ b/src/api/contest/dto/response/contest-hall-of-fame-response.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ContestEntryDto, ContestInfoDto } from './contest-entry.dto';
+
+export class HallOfFameItemDto {
+    @ApiProperty({ description: '콘테스트 ID' })
+    contestId: string;
+
+    @ApiProperty({ description: '콘테스트 제목' })
+    contestTitle: string;
+
+    @ApiProperty({ description: '콘테스트 시작일 ISO' })
+    startDate: string;
+
+    @ApiProperty({ description: '콘테스트 종료일 ISO' })
+    endDate: string;
+
+    @ApiProperty({ description: '우승자 항목', type: ContestEntryDto })
+    winner: ContestEntryDto;
+}
+
+export class ContestHallOfFameResponseDto {
+    @ApiProperty({ type: [HallOfFameItemDto] })
+    items: HallOfFameItemDto[];
+
+    @ApiProperty()
+    total: number;
+
+    @ApiProperty()
+    page: number;
+
+    @ApiProperty()
+    limit: number;
+}
+
+export class ContestPreviousRankingResponseDto {
+    @ApiProperty({ type: ContestInfoDto })
+    contest: ContestInfoDto;
+
+    @ApiProperty({ description: '저번 콘테스트 1~3위', type: [ContestEntryDto] })
+    ranking: ContestEntryDto[];
+}

--- a/src/api/contest/infrastructure/contest-asset-url-storage.adapter.ts
+++ b/src/api/contest/infrastructure/contest-asset-url-storage.adapter.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+
+import { StorageService } from '../../../common/storage/storage.service';
+import type { ContestAssetUrlPort } from '../application/ports/contest-asset-url.port';
+
+@Injectable()
+export class ContestAssetUrlStorageAdapter implements ContestAssetUrlPort {
+    constructor(private readonly storage: StorageService) {}
+
+    generateSignedUrl(fileName: string): Promise<string> {
+        return Promise.resolve(this.storage.generateSignedUrl(fileName));
+    }
+}

--- a/src/api/contest/infrastructure/contest-reader-mongoose.adapter.ts
+++ b/src/api/contest/infrastructure/contest-reader-mongoose.adapter.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+
+import type { ContestDocument } from '../../../schema/contest.schema';
+import type { ContestEntryDocument } from '../../../schema/contest-entry.schema';
+import {
+    type ContestEntrySnapshot,
+    type ContestReaderPort,
+    type ContestSnapshot,
+} from '../application/ports/contest-reader.port';
+import { ContestRepository } from '../repository/contest.repository';
+
+@Injectable()
+export class ContestReaderMongooseAdapter implements ContestReaderPort {
+    constructor(private readonly repository: ContestRepository) {}
+
+    async findActive(): Promise<ContestSnapshot | null> {
+        const doc = await this.repository.findActiveContest();
+        return doc ? this.toContestSnapshot(doc) : null;
+    }
+
+    async findLatestEnded(): Promise<ContestSnapshot | null> {
+        const doc = await this.repository.findLatestEndedContest();
+        return doc ? this.toContestSnapshot(doc) : null;
+    }
+
+    async findAllEnded(query: { page: number; limit: number }): Promise<ContestSnapshot[]> {
+        const skip = (query.page - 1) * query.limit;
+        const docs = await this.repository.findEndedContests(skip, query.limit);
+        return docs.map((d) => this.toContestSnapshot(d));
+    }
+
+    countAllEnded(): Promise<number> {
+        return this.repository.countEndedContests();
+    }
+
+    async findTopEntries(contestId: string, limit: number): Promise<ContestEntrySnapshot[]> {
+        const docs = await this.repository.findTopEntries(contestId, limit);
+        return docs.map((d) => this.toEntrySnapshot(d));
+    }
+
+    async findEntries(contestId: string, query: { page: number; limit: number }): Promise<ContestEntrySnapshot[]> {
+        const skip = (query.page - 1) * query.limit;
+        const docs = await this.repository.findEntries(contestId, skip, query.limit);
+        return docs.map((d) => this.toEntrySnapshot(d));
+    }
+
+    countEntries(contestId: string): Promise<number> {
+        return this.repository.countEntries(contestId);
+    }
+
+    async findEntryByUserId(contestId: string, userId: string): Promise<ContestEntrySnapshot | null> {
+        const doc = await this.repository.findEntryByUserId(contestId, userId);
+        return doc ? this.toEntrySnapshot(doc) : null;
+    }
+
+    async findEntryById(entryId: string): Promise<ContestEntrySnapshot | null> {
+        const doc = await this.repository.findEntryById(entryId);
+        return doc ? this.toEntrySnapshot(doc) : null;
+    }
+
+    async findVotedEntryId(contestId: string, voterId: string): Promise<string | null> {
+        const vote = await this.repository.findVote(contestId, voterId);
+        return vote ? vote.entryId.toString() : null;
+    }
+
+    private toContestSnapshot(doc: ContestDocument): ContestSnapshot {
+        return {
+            id: doc._id.toString(),
+            title: doc.title,
+            description: doc.description,
+            benefitText: doc.benefitText ?? '',
+            startDate: doc.startDate,
+            endDate: doc.endDate,
+            status: doc.status as 'active' | 'ended',
+            participantCount: doc.participantCount ?? 0,
+            createdAt: doc.createdAt,
+        };
+    }
+
+    private toEntrySnapshot(doc: ContestEntryDocument): ContestEntrySnapshot {
+        return {
+            id: doc._id.toString(),
+            contestId: doc.contestId.toString(),
+            userId: doc.userId,
+            userDisplayName: doc.userDisplayName,
+            userProfileImageFileName: doc.userProfileImageFileName ?? null,
+            photoFileName: doc.photoFileName,
+            description: doc.description,
+            voteCount: doc.voteCount ?? 0,
+            rank: doc.rank ?? null,
+            createdAt: doc.createdAt,
+        };
+    }
+}

--- a/src/api/contest/infrastructure/contest-user-info-mongoose.adapter.ts
+++ b/src/api/contest/infrastructure/contest-user-info-mongoose.adapter.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+import { Adopter, AdopterDocument } from '../../../schema/adopter.schema';
+import { Breeder, BreederDocument } from '../../../schema/breeder.schema';
+import type { ContestUserInfoPort, ContestUserInfoSnapshot } from '../application/ports/contest-user-info.port';
+
+@Injectable()
+export class ContestUserInfoMongooseAdapter implements ContestUserInfoPort {
+    constructor(
+        @InjectModel(Adopter.name) private readonly adopterModel: Model<AdopterDocument>,
+        @InjectModel(Breeder.name) private readonly breederModel: Model<BreederDocument>,
+    ) {}
+
+    async readUserInfo(userId: string, role: 'adopter' | 'breeder'): Promise<ContestUserInfoSnapshot | null> {
+        if (!Types.ObjectId.isValid(userId)) return null;
+
+        if (role === 'adopter') {
+            const adopter = await this.adopterModel
+                .findById(userId)
+                .select({ nickname: 1, profileImageFileName: 1 })
+                .lean<AdopterDocument>()
+                .exec();
+            if (!adopter) return null;
+            return {
+                displayName: adopter.nickname ?? '',
+                profileImageFileName: adopter.profileImageFileName ?? null,
+            };
+        }
+
+        const breeder = await this.breederModel
+            .findById(userId)
+            .select({ nickname: 1, name: 1, profileImageFileName: 1 })
+            .lean<BreederDocument>()
+            .exec();
+        if (!breeder) return null;
+
+        const displayName = (breeder.name && breeder.name.trim()) || breeder.nickname || '';
+        return {
+            displayName,
+            profileImageFileName: breeder.profileImageFileName ?? null,
+        };
+    }
+}

--- a/src/api/contest/infrastructure/contest-writer-mongoose.adapter.ts
+++ b/src/api/contest/infrastructure/contest-writer-mongoose.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+import { type CreateContestEntryData, type ContestWriterPort } from '../application/ports/contest-writer.port';
+import { ContestRepository } from '../repository/contest.repository';
+
+@Injectable()
+export class ContestWriterMongooseAdapter implements ContestWriterPort {
+    constructor(private readonly repository: ContestRepository) {}
+
+    createEntry(data: CreateContestEntryData): Promise<string> {
+        return this.repository.createEntry(data);
+    }
+
+    incrementParticipantCount(contestId: string): Promise<void> {
+        return this.repository.incrementParticipantCount(contestId);
+    }
+
+    vote(data: { contestId: string; entryId: string; voterId: string }): Promise<number> {
+        return this.repository.vote(data);
+    }
+}

--- a/src/api/contest/repository/contest.repository.ts
+++ b/src/api/contest/repository/contest.repository.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+import { Contest, ContestDocument } from '../../../schema/contest.schema';
+import { ContestEntry, ContestEntryDocument } from '../../../schema/contest-entry.schema';
+import { ContestVote, ContestVoteDocument } from '../../../schema/contest-vote.schema';
+
+@Injectable()
+export class ContestRepository {
+    constructor(
+        @InjectModel(Contest.name) private readonly contestModel: Model<ContestDocument>,
+        @InjectModel(ContestEntry.name) private readonly entryModel: Model<ContestEntryDocument>,
+        @InjectModel(ContestVote.name) private readonly voteModel: Model<ContestVoteDocument>,
+    ) {}
+
+    findActiveContest(): Promise<ContestDocument | null> {
+        return this.contestModel.findOne({ status: 'active' }).sort({ startDate: -1 }).lean<ContestDocument>().exec();
+    }
+
+    findLatestEndedContest(): Promise<ContestDocument | null> {
+        return this.contestModel.findOne({ status: 'ended' }).sort({ endDate: -1 }).lean<ContestDocument>().exec();
+    }
+
+    findEndedContests(skip: number, limit: number): Promise<ContestDocument[]> {
+        return this.contestModel
+            .find({ status: 'ended' })
+            .sort({ endDate: -1 })
+            .skip(skip)
+            .limit(limit)
+            .lean<ContestDocument[]>()
+            .exec();
+    }
+
+    countEndedContests(): Promise<number> {
+        return this.contestModel.countDocuments({ status: 'ended' }).exec();
+    }
+
+    incrementParticipantCount(contestId: string): Promise<void> {
+        return this.contestModel
+            .updateOne({ _id: new Types.ObjectId(contestId) }, { $inc: { participantCount: 1 } })
+            .exec()
+            .then(() => undefined);
+    }
+
+    findTopEntries(contestId: string, limit: number): Promise<ContestEntryDocument[]> {
+        return this.entryModel
+            .find({ contestId: new Types.ObjectId(contestId) })
+            .sort({ voteCount: -1, createdAt: 1 })
+            .limit(limit)
+            .lean<ContestEntryDocument[]>()
+            .exec();
+    }
+
+    findEntries(contestId: string, skip: number, limit: number): Promise<ContestEntryDocument[]> {
+        return this.entryModel
+            .find({ contestId: new Types.ObjectId(contestId) })
+            .sort({ voteCount: -1, createdAt: 1 })
+            .skip(skip)
+            .limit(limit)
+            .lean<ContestEntryDocument[]>()
+            .exec();
+    }
+
+    countEntries(contestId: string): Promise<number> {
+        return this.entryModel.countDocuments({ contestId: new Types.ObjectId(contestId) }).exec();
+    }
+
+    findEntryByUserId(contestId: string, userId: string): Promise<ContestEntryDocument | null> {
+        return this.entryModel
+            .findOne({ contestId: new Types.ObjectId(contestId), userId })
+            .lean<ContestEntryDocument>()
+            .exec();
+    }
+
+    findEntryById(entryId: string): Promise<ContestEntryDocument | null> {
+        if (!Types.ObjectId.isValid(entryId)) return Promise.resolve(null);
+        return this.entryModel.findById(entryId).lean<ContestEntryDocument>().exec();
+    }
+
+    async createEntry(data: {
+        contestId: string;
+        userId: string;
+        userDisplayName: string;
+        userProfileImageFileName: string | null;
+        photoFileName: string;
+        description: string;
+    }): Promise<string> {
+        const doc = await this.entryModel.create({
+            contestId: new Types.ObjectId(data.contestId),
+            userId: data.userId,
+            userDisplayName: data.userDisplayName,
+            userProfileImageFileName: data.userProfileImageFileName,
+            photoFileName: data.photoFileName,
+            description: data.description,
+        });
+        return doc._id.toString();
+    }
+
+    findVote(contestId: string, voterId: string): Promise<ContestVoteDocument | null> {
+        return this.voteModel
+            .findOne({ contestId: new Types.ObjectId(contestId), voterId })
+            .lean<ContestVoteDocument>()
+            .exec();
+    }
+
+    async vote(data: { contestId: string; entryId: string; voterId: string }): Promise<number> {
+        await this.voteModel.create({
+            contestId: new Types.ObjectId(data.contestId),
+            entryId: new Types.ObjectId(data.entryId),
+            voterId: data.voterId,
+        });
+
+        const updated = await this.entryModel
+            .findByIdAndUpdate(new Types.ObjectId(data.entryId), { $inc: { voteCount: 1 } }, { new: true })
+            .lean<ContestEntryDocument>()
+            .exec();
+
+        return updated?.voteCount ?? 0;
+    }
+}

--- a/src/api/contest/swagger/index.ts
+++ b/src/api/contest/swagger/index.ts
@@ -1,0 +1,71 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { ContestCurrentResponseDto } from '../dto/response/contest-current-response.dto';
+import {
+    ContestEntriesResponseDto,
+    ContestSubmitResponseDto,
+    ContestVoteResponseDto,
+} from '../dto/response/contest-entries-response.dto';
+import { ContestHallOfFameResponseDto, ContestPreviousRankingResponseDto } from '../dto/response/contest-hall-of-fame-response.dto';
+
+function ApiContestTag() {
+    return ApiTags('contest');
+}
+
+export function ApiGetCurrentContestEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '현재 콘테스트 조회', description: '진행 중인 콘테스트 정보 + 실시간 1~3위 랭킹을 반환합니다. 콘테스트가 없으면 data: null.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiGetContestEntriesEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '투표 항목 목록 조회', description: '현재 콘테스트의 항목 목록을 voteCount 내림차순으로 반환합니다.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiSubmitContestEntryEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '콘테스트 참여', description: '사진+설명으로 현재 콘테스트에 참여합니다. 유저당 1회 제한.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiVoteContestEntryEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '투표하기', description: '항목에 투표합니다. 콘테스트당 1회 제한. 자신의 항목에는 투표 불가.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiGetMyContestEntryEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '나의 참여 항목 조회', description: '현재 콘테스트에서 내가 올린 항목을 조회합니다. 없으면 data: null.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiGetPreviousRankingEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '저번 콘테스트 랭킹', description: '가장 최근 종료된 콘테스트의 1~3위를 반환합니다.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}
+
+export function ApiGetHallOfFameEndpoint() {
+    return applyDecorators(
+        ApiContestTag(),
+        ApiOperation({ summary: '명예의 전당 목록', description: '역대 콘테스트 우승자 목록을 최신순으로 반환합니다.' }),
+        ApiResponse({ status: 200, type: ApiResponseDto }),
+    );
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,6 +41,7 @@ import { AppVersionModule } from './api/app-version/app-version.module';
 import { InquiryModule } from './api/inquiry/inquiry.module';
 import { FeedModule } from './api/feed/feed.module';
 import { ChatModule } from './api/chat/chat.module';
+import { ContestModule } from './api/contest/contest.module';
 
 @Module({
     imports: [
@@ -86,6 +87,7 @@ import { ChatModule } from './api/chat/chat.module';
         InquiryModule,
         FeedModule,
         ChatModule,
+        ContestModule,
     ],
     controllers: [],
     providers: [],

--- a/src/schema/contest-entry.schema.ts
+++ b/src/schema/contest-entry.schema.ts
@@ -1,0 +1,52 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type ContestEntryDocument = ContestEntry &
+    Document & {
+        _id: Types.ObjectId;
+        createdAt: Date;
+        updatedAt: Date;
+    };
+
+/**
+ * 콘테스트 참여 항목.
+ * 유저가 사진+설명으로 콘테스트에 제출하며, 다른 유저가 투표할 수 있다.
+ * 유저당 콘테스트당 1회 제출 제한 (unique index).
+ */
+@Schema({ timestamps: true, collection: 'contest_entries' })
+export class ContestEntry {
+    @Prop({ type: Types.ObjectId, ref: 'Contest', required: true, index: true })
+    contestId: Types.ObjectId;
+
+    /** 제출한 유저 ID (문자열) */
+    @Prop({ required: true, index: true })
+    userId: string;
+
+    /** 표시용 닉네임 (제출 시 스냅샷) */
+    @Prop({ required: true })
+    userDisplayName: string;
+
+    /** 프로필 이미지 파일명 (스냅샷, signed URL 변환은 use-case 에서 수행) */
+    @Prop({ default: null })
+    userProfileImageFileName: string | null;
+
+    /** S3 파일명 (signed URL 로 변환해서 응답) */
+    @Prop({ required: true })
+    photoFileName: string;
+
+    @Prop({ required: true })
+    description: string;
+
+    /** 받은 투표 수 (투표 시 원자적 +1) */
+    @Prop({ default: 0, index: true })
+    voteCount: number;
+
+    /** 콘테스트 종료 후 순위 (1~3 = 명예의 전당). null = 미집계 또는 3위 밖 */
+    @Prop({ type: Number, default: null })
+    rank: number | null;
+}
+
+export const ContestEntrySchema = SchemaFactory.createForClass(ContestEntry);
+
+/** 유저당 콘테스트당 1회 제출 제한 */
+ContestEntrySchema.index({ contestId: 1, userId: 1 }, { unique: true });

--- a/src/schema/contest-vote.schema.ts
+++ b/src/schema/contest-vote.schema.ts
@@ -1,0 +1,30 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type ContestVoteDocument = ContestVote &
+    Document & {
+        _id: Types.ObjectId;
+        createdAt: Date;
+    };
+
+/**
+ * 콘테스트 투표 기록.
+ * 유저는 콘테스트당 1회 투표 가능 (unique index on contestId + voterId).
+ */
+@Schema({ timestamps: { createdAt: true, updatedAt: false }, collection: 'contest_votes' })
+export class ContestVote {
+    @Prop({ type: Types.ObjectId, ref: 'Contest', required: true, index: true })
+    contestId: Types.ObjectId;
+
+    @Prop({ type: Types.ObjectId, ref: 'ContestEntry', required: true, index: true })
+    entryId: Types.ObjectId;
+
+    /** 투표한 유저 ID */
+    @Prop({ required: true, index: true })
+    voterId: string;
+}
+
+export const ContestVoteSchema = SchemaFactory.createForClass(ContestVote);
+
+/** 유저당 콘테스트당 1회 투표 제한 */
+ContestVoteSchema.index({ contestId: 1, voterId: 1 }, { unique: true });

--- a/src/schema/contest.schema.ts
+++ b/src/schema/contest.schema.ts
@@ -1,0 +1,41 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type ContestDocument = Contest &
+    Document & {
+        _id: Types.ObjectId;
+        createdAt: Date;
+        updatedAt: Date;
+    };
+
+/**
+ * 주간 콘테스트 스키마 (명예의 전당).
+ * 매주 하나의 콘테스트가 active 상태로 운영되며 종료 후 ended 로 전환된다.
+ */
+@Schema({ timestamps: true, collection: 'contests' })
+export class Contest {
+    @Prop({ required: true })
+    title: string;
+
+    @Prop({ required: true })
+    description: string;
+
+    /** 참여 혜택 안내 문구 */
+    @Prop({ default: '' })
+    benefitText: string;
+
+    @Prop({ required: true, index: true })
+    startDate: Date;
+
+    @Prop({ required: true, index: true })
+    endDate: Date;
+
+    @Prop({ type: String, enum: ['active', 'ended'], default: 'active', index: true })
+    status: string;
+
+    /** 참여자 수 (entry 생성 시 +1) */
+    @Prop({ default: 0 })
+    participantCount: number;
+}
+
+export const ContestSchema = SchemaFactory.createForClass(Contest);


### PR DESCRIPTION
## Summary
- 피그마 화면 315:5985(명예의 전당), 716:65272(나의 참여), 350:2356(참여 모달), 490:941(실시간 랭킹) 대응 API 전체 구현
- 완전 미구현 상태였던 콘테스트 도메인을 헥사고날 아키텍처로 신규 추가

## 구현 내용

### 스키마
- `Contest` — 주간 콘테스트 (title, startDate, endDate, status, participantCount)
- `ContestEntry` — 참여 항목 (userId+contestId unique → 1인 1참여)
- `ContestVote` — 투표 기록 (voterId+contestId unique → 1인 1투표)

### API (모두 `/v2/contest/*`)
| Method | Path | 설명 |
|--------|------|------|
| GET | `/v2/contest/current` | 진행 중 콘테스트 + 실시간 1~3위 랭킹 |
| GET | `/v2/contest/entries` | 투표 항목 목록 (voteCount 내림차순 페이지네이션) |
| POST | `/v2/contest/entry` | 콘테스트 참여 (사진+설명, 1회 제한) |
| POST | `/v2/contest/vote/:entryId` | 투표하기 (콘테스트당 1회, 자신 항목 불가) |
| GET | `/v2/contest/me/entry` | 나의 참여 항목 조회 |
| GET | `/v2/contest/previous-ranking` | 저번 콘테스트 1~3위 |
| GET | `/v2/contest/hall-of-fame` | 역대 우승자 목록 |

### 계층 구조
- Port 4종 (reader / writer / asset-url / user-info)
- Use-case 7개
- Adapter 4종 (mongoose reader/writer/user-info + storage)
- Repository 1개 (모든 Mongo 쿼리 캡슐화)

## Test plan
- [ ] `GET v2/contest/current` — active 콘테스트 없을 때 data: null 반환 확인
- [ ] `POST v2/contest/entry` — 동일 유저 2회 참여 시 400 확인
- [ ] `POST v2/contest/vote/:entryId` — 자신 항목 투표 시 400 확인
- [ ] `POST v2/contest/vote/:entryId` — 2회 투표 시 400 확인
- [ ] `GET v2/contest/entries` — 로그인 유저의 hasVoted / isMyEntry 필드 확인