### PR TITLE
feat: 탐색 탭 키워드 검색 · 저장 피드 · 팔로우 (v2)

### DIFF
--- a/src/api/adoption/application/ports/adoption-pet-reader.port.ts
+++ b/src/api/adoption/application/ports/adoption-pet-reader.port.ts
@@ -8,6 +8,8 @@ export type AdoptionPetListQuery = {
     excludePetId?: string;
     /** 분양 상태 필터 — 분양가능/예약중/분양완료 탭 (Figma 678:49176/49772/52698) */
     status?: AdoptionPetStatus;
+    /** 검색 키워드 — 이름·품종 부분 일치 (Figma 678:43115 탐색 입양 탭) */
+    keyword?: string;
     sort: AdoptionPetSort;
     skip: number;
     limit: number;
@@ -63,7 +65,7 @@ export const ADOPTION_PET_READER_PORT = Symbol('ADOPTION_PET_READER_PORT');
 
 export interface AdoptionPetReaderPort {
     countList(
-        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status' | 'keyword'>,
     ): Promise<number>;
     readList(query: AdoptionPetListQuery): Promise<AdoptionPetSnapshot[]>;
     readPopular(petType: AdoptionPetType | undefined, limit: number): Promise<AdoptionPetSnapshot[]>;

--- a/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
+++ b/src/api/adoption/application/use-cases/get-adoption-pet-list.use-case.ts
@@ -36,6 +36,7 @@ export class GetAdoptionPetListUseCase {
         breederId?: string;
         excludePetId?: string;
         status?: AdoptionPetStatus;
+        keyword?: string;
         sort?: AdoptionPetListQuery['sort'];
         page?: number;
         pageSize?: number;
@@ -50,6 +51,7 @@ export class GetAdoptionPetListUseCase {
             breederId: input.breederId,
             excludePetId: input.excludePetId,
             status: input.status,
+            keyword: input.keyword,
             sort,
             skip: (page - 1) * pageSize,
             limit: pageSize,
@@ -61,6 +63,7 @@ export class GetAdoptionPetListUseCase {
                 breederId: input.breederId,
                 excludePetId: input.excludePetId,
                 status: input.status,
+                keyword: input.keyword,
             }),
             this.petReader.readList(query),
         ]);

--- a/src/api/adoption/controller/adoption-list.controller.ts
+++ b/src/api/adoption/controller/adoption-list.controller.ts
@@ -32,6 +32,7 @@ export class AdoptionListController {
             breederId: query.breederId,
             excludePetId: query.excludePetId,
             status: query.status,
+            keyword: query.keyword,
             sort: query.sort,
             page: query.page,
             pageSize: query.pageSize,

--- a/src/api/adoption/dto/request/adoption-list-query.dto.ts
+++ b/src/api/adoption/dto/request/adoption-list-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsMongoId, IsOptional, Max, Min } from 'class-validator';
+import { IsEnum, IsInt, IsMongoId, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 export enum AdoptionPetTypeQuery {
     DOG = 'dog',
@@ -56,6 +56,16 @@ export class AdoptionListQueryDto {
     @IsOptional()
     @IsEnum(AdoptionStatusQuery)
     status?: AdoptionStatusQuery;
+
+    @ApiProperty({
+        description: '검색 키워드 — 이름·품종 부분 일치 (Figma 678:43115 탐색 입양 탭)',
+        required: false,
+        example: '말티즈',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(50)
+    keyword?: string;
 
     @ApiProperty({
         description: '정렬 기준',

--- a/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
+++ b/src/api/adoption/infrastructure/adoption-pet-mongoose-reader.adapter.ts
@@ -15,7 +15,7 @@ export class AdoptionPetMongooseReaderAdapter implements AdoptionPetReaderPort {
     constructor(private readonly repository: AdoptionPetRepository) {}
 
     countList(
-        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status' | 'keyword'>,
     ): Promise<number> {
         return this.repository.countList(query);
     }

--- a/src/api/adoption/repository/adoption-pet.repository.ts
+++ b/src/api/adoption/repository/adoption-pet.repository.ts
@@ -18,6 +18,7 @@ export class AdoptionPetRepository {
         breederId?: string;
         excludePetId?: string;
         status?: AdoptionPetStatus;
+        keyword?: string;
     }): FilterQuery<AvailablePet> {
         const filter: FilterQuery<AvailablePet> = { isActive: true };
         if (input.petType) {
@@ -32,11 +33,17 @@ export class AdoptionPetRepository {
         if (input.status) {
             filter.status = input.status;
         }
+        if (input.keyword && input.keyword.trim()) {
+            // 정규식 특수문자 이스케이프 처리 (ReDoS 방지)
+            const escaped = input.keyword.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const regex = new RegExp(escaped, 'i');
+            filter.$or = [{ name: regex }, { breed: regex }];
+        }
         return filter;
     }
 
     countList(
-        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status'>,
+        query: Pick<AdoptionPetListQuery, 'petType' | 'breederId' | 'excludePetId' | 'status' | 'keyword'>,
     ): Promise<number> {
         return this.model.countDocuments(this.buildBaseFilter(query)).exec();
     }

--- a/src/api/adoption/test/application/use-cases/add-adoption-pet-favorite.use-case.spec.ts
+++ b/src/api/adoption/test/application/use-cases/add-adoption-pet-favorite.use-case.spec.ts
@@ -25,9 +25,7 @@ describe('AddAdoptionPetFavoriteUseCase', () => {
     it('soft-deleted(isActive=false) 펫은 readActiveById 가 null 반환 → 추가 거부', async () => {
         // 즐겨찾기 추가 가드: soft-deleted 펫에 stale 즐겨찾기/카운터가 쌓이지 않도록 readActiveById 사용.
         petReader.readActiveById.mockResolvedValueOnce(null);
-        await expect(useCase.execute('adopter-1', 'pet-soft-deleted')).rejects.toThrow(
-            '해당 동물을 찾을 수 없습니다.',
-        );
+        await expect(useCase.execute('adopter-1', 'pet-soft-deleted')).rejects.toThrow('해당 동물을 찾을 수 없습니다.');
         expect(favoriteWriter.addAtomic).not.toHaveBeenCalled();
     });
 

--- a/src/api/auth/auth.module-definition.ts
+++ b/src/api/auth/auth.module-definition.ts
@@ -10,6 +10,8 @@ import { JwtStrategy } from '../../common/strategy/jwt.strategy';
 import { NaverStrategy } from '../../common/strategy/naver.strategy';
 import { KakaoStrategy } from '../../common/strategy/kakao.strategy';
 import { GoogleStrategy } from '../../common/strategy/google.strategy';
+import { JWT_USER_STATUS_PORT } from '../../common/strategy/ports/jwt-user-status.port';
+import { JwtUserStatusMongooseAdapter } from '../../common/strategy/infrastructure/jwt-user-status-mongoose.adapter';
 import { CustomLoggerService } from '../../common/logger/custom-logger.service';
 import { StorageModule } from '../../common/storage/storage.module';
 import { DiscordWebhookModule } from '../../common/discord/discord-webhook.module';
@@ -339,7 +341,18 @@ const AUTH_PORT_BINDINGS = [
     },
 ];
 
-const AUTH_STRATEGY_PROVIDERS = [JwtStrategy, GoogleStrategy, NaverStrategy, KakaoStrategy, CustomLoggerService];
+const AUTH_STRATEGY_PROVIDERS = [
+    JwtUserStatusMongooseAdapter,
+    {
+        provide: JWT_USER_STATUS_PORT,
+        useExisting: JwtUserStatusMongooseAdapter,
+    },
+    JwtStrategy,
+    GoogleStrategy,
+    NaverStrategy,
+    KakaoStrategy,
+    CustomLoggerService,
+];
 
 export const AUTH_MODULE_PROVIDERS = [
     ...AUTH_USE_CASE_PROVIDERS,

--- a/src/api/chat/application/ports/chat-interaction.port.ts
+++ b/src/api/chat/application/ports/chat-interaction.port.ts
@@ -1,8 +1,7 @@
 import { ChatRoomSnapshot } from './chat-room-manager.port';
 import { ChatMessageSnapshot } from './chat-message-manager.port';
 import { SenderRole } from '../../../../schema/chat-message.schema';
-import { CreateRoomRequestDto } from '../../dto/request/create-room-request.dto';
-import { SendMessageRequestDto } from '../../dto/request/send-message-request.dto';
+import type { CreateRoomCommand, SendMessageCommand } from '../types/chat-command.type';
 
 export const CREATE_OR_GET_ROOM_USE_CASE = Symbol('CREATE_OR_GET_ROOM_USE_CASE');
 export const GET_MY_ROOMS_USE_CASE = Symbol('GET_MY_ROOMS_USE_CASE');
@@ -11,7 +10,7 @@ export const GET_MESSAGES_USE_CASE = Symbol('GET_MESSAGES_USE_CASE');
 export const CLOSE_ROOM_USE_CASE = Symbol('CLOSE_ROOM_USE_CASE');
 
 export interface CreateOrGetRoomUseCasePort {
-    execute(adopterId: string, dto: CreateRoomRequestDto): Promise<ChatRoomSnapshot>;
+    execute(adopterId: string, command: CreateRoomCommand): Promise<ChatRoomSnapshot>;
 }
 
 export interface GetMyRoomsUseCasePort {
@@ -19,7 +18,7 @@ export interface GetMyRoomsUseCasePort {
 }
 
 export interface SendMessageUseCasePort {
-    execute(senderId: string, senderRole: SenderRole, dto: SendMessageRequestDto): Promise<ChatMessageSnapshot>;
+    execute(senderId: string, senderRole: SenderRole, command: SendMessageCommand): Promise<ChatMessageSnapshot>;
 }
 
 export interface GetMessagesUseCasePort {

--- a/src/api/community/application/ports/community-bookmark.port.ts
+++ b/src/api/community/application/ports/community-bookmark.port.ts
@@ -1,0 +1,29 @@
+import type { CommunityAuthorModel } from '../types/community-post.type';
+
+export const COMMUNITY_BOOKMARK_PORT = Symbol('COMMUNITY_BOOKMARK_PORT');
+
+export interface CommunityBookmarkPort {
+    /**
+     * 게시글 저장. 이미 저장된 경우 alreadySaved: true 반환 (멱등).
+     * 새로 저장된 경우 community_posts.saveCount += 1.
+     */
+    save(postId: string, userId: string, userModel: CommunityAuthorModel): Promise<{ alreadySaved: boolean }>;
+
+    /**
+     * 게시글 저장 취소. 저장되지 않은 경우 wasSaved: false 반환 (멱등).
+     * 취소 시 community_posts.saveCount -= 1 (0 미만 방지).
+     */
+    unsave(postId: string, userId: string): Promise<{ wasSaved: boolean }>;
+
+    /**
+     * 저장된 게시글 ID 목록 (저장일 내림차순).
+     * 저장 피드 페이지네이션용.
+     */
+    listSavedPostIds(userId: string, skip: number, limit: number): Promise<{ postIds: string[]; totalItems: number }>;
+
+    /**
+     * 주어진 postId 배열 중 현재 userId 가 저장한 것의 Set.
+     * 목록 렌더링 시 isSaved 플래그 계산용.
+     */
+    findSavedPostIds(userId: string, postIds: string[]): Promise<Set<string>>;
+}

--- a/src/api/community/application/use-cases/get-my-saved-community-posts.use-case.ts
+++ b/src/api/community/application/use-cases/get-my-saved-community-posts.use-case.ts
@@ -38,9 +38,9 @@ export class GetMySavedCommunityPostsUseCase {
         }
 
         // 저장 순서 유지하며 active 게시글만 포함
-        const snapshots = (
-            await Promise.all(postIds.map((id) => this.reader.readPostById(id)))
-        ).filter((s): s is NonNullable<typeof s> => s !== null);
+        const snapshots = (await Promise.all(postIds.map((id) => this.reader.readPostById(id)))).filter(
+            (s): s is NonNullable<typeof s> => s !== null,
+        );
 
         const items = snapshots.map((s) => this.mapper.toCard(s));
         return buildPageResult(items, page, pageSize, totalItems);

--- a/src/api/community/application/use-cases/get-my-saved-community-posts.use-case.ts
+++ b/src/api/community/application/use-cases/get-my-saved-community-posts.use-case.ts
@@ -1,0 +1,48 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { buildPageResult, type PageResult } from '../../../../common/types/page-result.type';
+import type { CommunityPostCardResponseDto } from '../../dto/response/community-post-card.dto';
+import { CommunityPostMapperService } from '../../domain/services/community-post-mapper.service';
+import { COMMUNITY_BOOKMARK_PORT, type CommunityBookmarkPort } from '../ports/community-bookmark.port';
+import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
+
+const PAGE_SIZE_DEFAULT = 15;
+const PAGE_SIZE_MAX = 60;
+
+@Injectable()
+export class GetMySavedCommunityPostsUseCase {
+    constructor(
+        @Inject(COMMUNITY_BOOKMARK_PORT)
+        private readonly bookmark: CommunityBookmarkPort,
+        @Inject(COMMUNITY_POST_READER_PORT)
+        private readonly reader: CommunityPostReaderPort,
+        private readonly mapper: CommunityPostMapperService,
+    ) {}
+
+    async execute(input: {
+        userId: string;
+        page?: number;
+        pageSize?: number;
+    }): Promise<PageResult<CommunityPostCardResponseDto>> {
+        const page = Math.max(1, input.page ?? 1);
+        const pageSize = Math.min(PAGE_SIZE_MAX, Math.max(1, input.pageSize ?? PAGE_SIZE_DEFAULT));
+
+        const { postIds, totalItems } = await this.bookmark.listSavedPostIds(
+            input.userId,
+            (page - 1) * pageSize,
+            pageSize,
+        );
+
+        if (postIds.length === 0) {
+            return buildPageResult([], page, pageSize, totalItems);
+        }
+
+        // 저장 순서 유지하며 active 게시글만 포함
+        const snapshots = (
+            await Promise.all(postIds.map((id) => this.reader.readPostById(id)))
+        ).filter((s): s is NonNullable<typeof s> => s !== null);
+
+        const items = snapshots.map((s) => this.mapper.toCard(s));
+        return buildPageResult(items, page, pageSize, totalItems);
+    }
+}

--- a/src/api/community/application/use-cases/save-community-post.use-case.ts
+++ b/src/api/community/application/use-cases/save-community-post.use-case.ts
@@ -1,0 +1,28 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { COMMUNITY_BOOKMARK_PORT, type CommunityBookmarkPort } from '../ports/community-bookmark.port';
+import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
+import type { CommunityAuthorModel } from '../types/community-post.type';
+
+@Injectable()
+export class SaveCommunityPostUseCase {
+    constructor(
+        @Inject(COMMUNITY_POST_READER_PORT)
+        private readonly reader: CommunityPostReaderPort,
+        @Inject(COMMUNITY_BOOKMARK_PORT)
+        private readonly bookmark: CommunityBookmarkPort,
+    ) {}
+
+    async execute(input: {
+        postId: string;
+        userId: string;
+        userModel: CommunityAuthorModel;
+    }): Promise<{ alreadySaved: boolean }> {
+        const exists = await this.reader.existsActivePost(input.postId);
+        if (!exists) {
+            throw new BadRequestException('해당 게시글을 찾을 수 없습니다.');
+        }
+
+        return this.bookmark.save(input.postId, input.userId, input.userModel);
+    }
+}

--- a/src/api/community/application/use-cases/unsave-community-post.use-case.ts
+++ b/src/api/community/application/use-cases/unsave-community-post.use-case.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { COMMUNITY_BOOKMARK_PORT, type CommunityBookmarkPort } from '../ports/community-bookmark.port';
+
+@Injectable()
+export class UnsaveCommunityPostUseCase {
+    constructor(
+        @Inject(COMMUNITY_BOOKMARK_PORT)
+        private readonly bookmark: CommunityBookmarkPort,
+    ) {}
+
+    execute(input: { postId: string; userId: string }): Promise<{ wasSaved: boolean }> {
+        return this.bookmark.unsave(input.postId, input.userId);
+    }
+}

--- a/src/api/community/community.module-definition.ts
+++ b/src/api/community/community.module-definition.ts
@@ -3,11 +3,13 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { StorageModule } from '../../common/storage/storage.module';
 import { Adopter, AdopterSchema } from '../../schema/adopter.schema';
 import { Breeder, BreederSchema } from '../../schema/breeder.schema';
+import { CommunityBookmark, CommunityBookmarkSchema } from '../../schema/community-bookmark.schema';
 import { CommunityPostComment, CommunityPostCommentSchema } from '../../schema/community-post-comment.schema';
 import { CommunityPost, CommunityPostSchema } from '../../schema/community-post.schema';
 
 import { COMMUNITY_ASSET_URL_PORT } from './application/ports/community-asset-url.port';
 import { COMMUNITY_AUTHOR_READER_PORT } from './application/ports/community-author-reader.port';
+import { COMMUNITY_BOOKMARK_PORT } from './application/ports/community-bookmark.port';
 import { COMMUNITY_POST_READER_PORT } from './application/ports/community-post-reader.port';
 import { COMMUNITY_POST_WRITER_PORT } from './application/ports/community-post-writer.port';
 import { CreateCommunityPostUseCase } from './application/use-cases/create-community-post.use-case';
@@ -15,7 +17,11 @@ import { DeleteCommunityPostUseCase } from './application/use-cases/delete-commu
 import { GetCommunityPostCommentsUseCase } from './application/use-cases/get-community-post-comments.use-case';
 import { GetCommunityPostDetailUseCase } from './application/use-cases/get-community-post-detail.use-case';
 import { GetCommunityPostListUseCase } from './application/use-cases/get-community-post-list.use-case';
+import { GetMySavedCommunityPostsUseCase } from './application/use-cases/get-my-saved-community-posts.use-case';
+import { SaveCommunityPostUseCase } from './application/use-cases/save-community-post.use-case';
+import { UnsaveCommunityPostUseCase } from './application/use-cases/unsave-community-post.use-case';
 import { UpdateCommunityPostUseCase } from './application/use-cases/update-community-post.use-case';
+import { CommunityPostBookmarkController } from './controller/community-post-bookmark.controller';
 import { CommunityPostDetailController } from './controller/community-post-detail.controller';
 import { CommunityPostListController } from './controller/community-post-list.controller';
 import { CommunityPostWriteController } from './controller/community-post-write.controller';
@@ -23,13 +29,16 @@ import { CommunityPostMapperService } from './domain/services/community-post-map
 import { CommunityPostWriteValidatorService } from './domain/services/community-post-write-validator.service';
 import { CommunityAssetUrlStorageAdapter } from './infrastructure/community-asset-url-storage.adapter';
 import { CommunityAuthorReaderMongooseAdapter } from './infrastructure/community-author-reader-mongoose.adapter';
+import { CommunityBookmarkMongooseAdapter } from './infrastructure/community-bookmark-mongoose.adapter';
 import { CommunityPostReaderMongooseAdapter } from './infrastructure/community-post-reader-mongoose.adapter';
 import { CommunityPostWriterMongooseAdapter } from './infrastructure/community-post-writer-mongoose.adapter';
+import { CommunityBookmarkRepository } from './repository/community-bookmark.repository';
 import { CommunityRepository } from './repository/community.repository';
 
 const SCHEMA_IMPORTS = MongooseModule.forFeature([
     { name: CommunityPost.name, schema: CommunityPostSchema },
     { name: CommunityPostComment.name, schema: CommunityPostCommentSchema },
+    { name: CommunityBookmark.name, schema: CommunityBookmarkSchema },
     { name: Adopter.name, schema: AdopterSchema },
     { name: Breeder.name, schema: BreederSchema },
 ]);
@@ -40,6 +49,7 @@ export const COMMUNITY_MODULE_CONTROLLERS = [
     CommunityPostListController,
     CommunityPostDetailController,
     CommunityPostWriteController,
+    CommunityPostBookmarkController,
 ];
 
 const USE_CASE_PROVIDERS = [
@@ -49,16 +59,21 @@ const USE_CASE_PROVIDERS = [
     CreateCommunityPostUseCase,
     UpdateCommunityPostUseCase,
     DeleteCommunityPostUseCase,
+    SaveCommunityPostUseCase,
+    UnsaveCommunityPostUseCase,
+    GetMySavedCommunityPostsUseCase,
 ];
 
 const DOMAIN_PROVIDERS = [CommunityPostMapperService, CommunityPostWriteValidatorService];
 
 const INFRASTRUCTURE_PROVIDERS = [
     CommunityRepository,
+    CommunityBookmarkRepository,
     CommunityPostReaderMongooseAdapter,
     CommunityPostWriterMongooseAdapter,
     CommunityAuthorReaderMongooseAdapter,
     CommunityAssetUrlStorageAdapter,
+    CommunityBookmarkMongooseAdapter,
 ];
 
 const PORT_BINDINGS = [
@@ -66,6 +81,7 @@ const PORT_BINDINGS = [
     { provide: COMMUNITY_POST_WRITER_PORT, useExisting: CommunityPostWriterMongooseAdapter },
     { provide: COMMUNITY_AUTHOR_READER_PORT, useExisting: CommunityAuthorReaderMongooseAdapter },
     { provide: COMMUNITY_ASSET_URL_PORT, useExisting: CommunityAssetUrlStorageAdapter },
+    { provide: COMMUNITY_BOOKMARK_PORT, useExisting: CommunityBookmarkMongooseAdapter },
 ];
 
 export const COMMUNITY_MODULE_PROVIDERS = [

--- a/src/api/community/constants/community-response-messages.ts
+++ b/src/api/community/constants/community-response-messages.ts
@@ -5,4 +5,7 @@ export const COMMUNITY_RESPONSE_MESSAGES = {
     created: '게시글이 등록되었습니다.',
     updated: '게시글이 수정되었습니다.',
     deleted: '게시글이 삭제되었습니다.',
+    saved: '게시글이 저장되었습니다.',
+    unsaved: '게시글 저장이 취소되었습니다.',
+    savedListRetrieved: '저장한 게시글 목록 조회 성공',
 } as const;

--- a/src/api/community/controller/community-post-bookmark.controller.ts
+++ b/src/api/community/controller/community-post-bookmark.controller.ts
@@ -9,7 +9,10 @@ import { UnsaveCommunityPostUseCase } from '../application/use-cases/unsave-comm
 import { COMMUNITY_RESPONSE_MESSAGES } from '../constants/community-response-messages';
 import { CommunityProtectedController } from '../decorator/community-protected-controller.decorator';
 import { CommunityPostPaginationQueryDto } from '../dto/request/community-post-list-query.dto';
-import type { CommunityBookmarkResponseDto, CommunityUnsaveResponseDto } from '../dto/response/community-bookmark-response.dto';
+import type {
+    CommunityBookmarkResponseDto,
+    CommunityUnsaveResponseDto,
+} from '../dto/response/community-bookmark-response.dto';
 import type { CommunityPostCardResponseDto } from '../dto/response/community-post-card.dto';
 import {
     ApiGetMySavedCommunityPostsEndpoint,
@@ -37,10 +40,7 @@ export class CommunityPostBookmarkController {
     ): Promise<ApiResponseDto<CommunityBookmarkResponseDto>> {
         const userModel = role === 'breeder' ? 'Breeder' : 'Adopter';
         const { alreadySaved } = await this.saveUseCase.execute({ postId, userId, userModel });
-        return ApiResponseDto.success(
-            { postId, saved: !alreadySaved },
-            COMMUNITY_RESPONSE_MESSAGES.saved,
-        );
+        return ApiResponseDto.success({ postId, saved: !alreadySaved }, COMMUNITY_RESPONSE_MESSAGES.saved);
     }
 
     @Delete('posts/:postId/bookmark')
@@ -50,10 +50,7 @@ export class CommunityPostBookmarkController {
         @CurrentUser('userId') userId: string,
     ): Promise<ApiResponseDto<CommunityUnsaveResponseDto>> {
         const { wasSaved } = await this.unsaveUseCase.execute({ postId, userId });
-        return ApiResponseDto.success(
-            { postId, unsaved: wasSaved },
-            COMMUNITY_RESPONSE_MESSAGES.unsaved,
-        );
+        return ApiResponseDto.success({ postId, unsaved: wasSaved }, COMMUNITY_RESPONSE_MESSAGES.unsaved);
     }
 
     @Get('posts/me/bookmarks')

--- a/src/api/community/controller/community-post-bookmark.controller.ts
+++ b/src/api/community/controller/community-post-bookmark.controller.ts
@@ -1,0 +1,75 @@
+import { Delete, Get, Param, Post, Query } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { PaginationResponseDto } from '../../../common/dto/pagination/pagination-response.dto';
+import { GetMySavedCommunityPostsUseCase } from '../application/use-cases/get-my-saved-community-posts.use-case';
+import { SaveCommunityPostUseCase } from '../application/use-cases/save-community-post.use-case';
+import { UnsaveCommunityPostUseCase } from '../application/use-cases/unsave-community-post.use-case';
+import { COMMUNITY_RESPONSE_MESSAGES } from '../constants/community-response-messages';
+import { CommunityProtectedController } from '../decorator/community-protected-controller.decorator';
+import { CommunityPostPaginationQueryDto } from '../dto/request/community-post-list-query.dto';
+import type { CommunityBookmarkResponseDto, CommunityUnsaveResponseDto } from '../dto/response/community-bookmark-response.dto';
+import type { CommunityPostCardResponseDto } from '../dto/response/community-post-card.dto';
+import {
+    ApiGetMySavedCommunityPostsEndpoint,
+    ApiSaveCommunityPostEndpoint,
+    ApiUnsaveCommunityPostEndpoint,
+} from '../swagger';
+
+/**
+ * v2 커뮤니티 게시글 저장(북마크) — 저장 피드 탭 (Figma 711:59266).
+ */
+@CommunityProtectedController()
+export class CommunityPostBookmarkController {
+    constructor(
+        private readonly saveUseCase: SaveCommunityPostUseCase,
+        private readonly unsaveUseCase: UnsaveCommunityPostUseCase,
+        private readonly getMySavedUseCase: GetMySavedCommunityPostsUseCase,
+    ) {}
+
+    @Post('posts/:postId/bookmark')
+    @ApiSaveCommunityPostEndpoint()
+    async save(
+        @Param('postId') postId: string,
+        @CurrentUser('userId') userId: string,
+        @CurrentUser('role') role: 'adopter' | 'breeder',
+    ): Promise<ApiResponseDto<CommunityBookmarkResponseDto>> {
+        const userModel = role === 'breeder' ? 'Breeder' : 'Adopter';
+        const { alreadySaved } = await this.saveUseCase.execute({ postId, userId, userModel });
+        return ApiResponseDto.success(
+            { postId, saved: !alreadySaved },
+            COMMUNITY_RESPONSE_MESSAGES.saved,
+        );
+    }
+
+    @Delete('posts/:postId/bookmark')
+    @ApiUnsaveCommunityPostEndpoint()
+    async unsave(
+        @Param('postId') postId: string,
+        @CurrentUser('userId') userId: string,
+    ): Promise<ApiResponseDto<CommunityUnsaveResponseDto>> {
+        const { wasSaved } = await this.unsaveUseCase.execute({ postId, userId });
+        return ApiResponseDto.success(
+            { postId, unsaved: wasSaved },
+            COMMUNITY_RESPONSE_MESSAGES.unsaved,
+        );
+    }
+
+    @Get('posts/me/bookmarks')
+    @ApiGetMySavedCommunityPostsEndpoint()
+    async getMySaved(
+        @CurrentUser('userId') userId: string,
+        @Query() query: CommunityPostPaginationQueryDto,
+    ): Promise<ApiResponseDto<PaginationResponseDto<CommunityPostCardResponseDto>>> {
+        const result = await this.getMySavedUseCase.execute({
+            userId,
+            page: query.page,
+            pageSize: query.pageSize,
+        });
+        return ApiResponseDto.success(
+            PaginationResponseDto.fromPageResult(result),
+            COMMUNITY_RESPONSE_MESSAGES.savedListRetrieved,
+        );
+    }
+}

--- a/src/api/community/dto/request/community-post-list-query.dto.ts
+++ b/src/api/community/dto/request/community-post-list-query.dto.ts
@@ -2,6 +2,23 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsEnum, IsInt, IsOptional, IsString, Matches, Max, MaxLength, Min } from 'class-validator';
 
+export class CommunityPostPaginationQueryDto {
+    @ApiPropertyOptional({ description: '페이지 (1-based)', example: 1, minimum: 1 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    page?: number = 1;
+
+    @ApiPropertyOptional({ description: '페이지 크기', example: 15, minimum: 1, maximum: 60 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(60)
+    pageSize?: number = 15;
+}
+
 export class CommunityPostListQueryDto {
     @ApiPropertyOptional({ description: '동물 종류 필터', enum: ['dog', 'cat', 'reptile'] })
     @IsOptional()

--- a/src/api/community/dto/response/community-bookmark-response.dto.ts
+++ b/src/api/community/dto/response/community-bookmark-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CommunityBookmarkResponseDto {
+    @ApiProperty({ description: '저장된 게시글 ID', example: '507f1f77bcf86cd799439011' })
+    postId: string;
+
+    @ApiProperty({ description: '저장 완료 여부 (false: 이미 저장됨 — 멱등)', example: true })
+    saved: boolean;
+}
+
+export class CommunityUnsaveResponseDto {
+    @ApiProperty({ description: '저장 취소된 게시글 ID', example: '507f1f77bcf86cd799439011' })
+    postId: string;
+
+    @ApiProperty({ description: '취소 완료 여부 (false: 저장 안 된 상태였음 — 멱등)', example: true })
+    unsaved: boolean;
+}

--- a/src/api/community/infrastructure/community-bookmark-mongoose.adapter.ts
+++ b/src/api/community/infrastructure/community-bookmark-mongoose.adapter.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+
+import type { CommunityBookmarkPort } from '../application/ports/community-bookmark.port';
+import type { CommunityAuthorModel } from '../application/types/community-post.type';
+import { CommunityBookmarkRepository } from '../repository/community-bookmark.repository';
+
+@Injectable()
+export class CommunityBookmarkMongooseAdapter implements CommunityBookmarkPort {
+    constructor(private readonly repository: CommunityBookmarkRepository) {}
+
+    save(postId: string, userId: string, userModel: CommunityAuthorModel): Promise<{ alreadySaved: boolean }> {
+        return this.repository.save(postId, userId, userModel);
+    }
+
+    unsave(postId: string, userId: string): Promise<{ wasSaved: boolean }> {
+        return this.repository.unsave(postId, userId);
+    }
+
+    listSavedPostIds(userId: string, skip: number, limit: number): Promise<{ postIds: string[]; totalItems: number }> {
+        return this.repository.listSavedPostIds(userId, skip, limit);
+    }
+
+    findSavedPostIds(userId: string, postIds: string[]): Promise<Set<string>> {
+        return this.repository.findSavedPostIds(userId, postIds);
+    }
+}

--- a/src/api/community/repository/community-bookmark.repository.ts
+++ b/src/api/community/repository/community-bookmark.repository.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+import {
+    CommunityBookmark,
+    CommunityBookmarkDocument,
+} from '../../../schema/community-bookmark.schema';
+import { CommunityPost, CommunityPostDocument } from '../../../schema/community-post.schema';
+
+@Injectable()
+export class CommunityBookmarkRepository {
+    constructor(
+        @InjectModel(CommunityBookmark.name)
+        private readonly bookmarkModel: Model<CommunityBookmarkDocument>,
+        @InjectModel(CommunityPost.name)
+        private readonly postModel: Model<CommunityPostDocument>,
+    ) {}
+
+    async save(
+        postId: string,
+        userId: string,
+        userModel: 'Adopter' | 'Breeder',
+    ): Promise<{ alreadySaved: boolean }> {
+        if (!Types.ObjectId.isValid(postId)) {
+            return { alreadySaved: false };
+        }
+        const postObjectId = new Types.ObjectId(postId);
+
+        try {
+            await this.bookmarkModel.create({ postId: postObjectId, userId, userModel });
+            await this.postModel.updateOne({ _id: postObjectId }, { $inc: { saveCount: 1 } }).exec();
+            return { alreadySaved: false };
+        } catch (err: unknown) {
+            // duplicate key error (code 11000) → 이미 저장됨
+            if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
+                return { alreadySaved: true };
+            }
+            throw err;
+        }
+    }
+
+    async unsave(postId: string, userId: string): Promise<{ wasSaved: boolean }> {
+        if (!Types.ObjectId.isValid(postId)) {
+            return { wasSaved: false };
+        }
+        const postObjectId = new Types.ObjectId(postId);
+        const result = await this.bookmarkModel.deleteOne({ postId: postObjectId, userId }).exec();
+
+        if (result.deletedCount === 0) {
+            return { wasSaved: false };
+        }
+
+        // saveCount 0 미만 방지
+        await this.postModel
+            .updateOne({ _id: postObjectId, saveCount: { $gt: 0 } }, { $inc: { saveCount: -1 } })
+            .exec();
+
+        return { wasSaved: true };
+    }
+
+    async listSavedPostIds(
+        userId: string,
+        skip: number,
+        limit: number,
+    ): Promise<{ postIds: string[]; totalItems: number }> {
+        const [docs, totalItems] = await Promise.all([
+            this.bookmarkModel
+                .find({ userId })
+                .sort({ createdAt: -1 })
+                .skip(skip)
+                .limit(limit)
+                .lean<{ postId: Types.ObjectId }[]>()
+                .exec(),
+            this.bookmarkModel.countDocuments({ userId }).exec(),
+        ]);
+
+        return {
+            postIds: docs.map((d) => String(d.postId)),
+            totalItems,
+        };
+    }
+
+    async findSavedPostIds(userId: string, postIds: string[]): Promise<Set<string>> {
+        const validIds = postIds.filter((id) => Types.ObjectId.isValid(id));
+        if (validIds.length === 0) return new Set();
+
+        const docs = await this.bookmarkModel
+            .find({ userId, postId: { $in: validIds.map((id) => new Types.ObjectId(id)) } })
+            .select('postId')
+            .lean<{ postId: Types.ObjectId }[]>()
+            .exec();
+
+        return new Set(docs.map((d) => String(d.postId)));
+    }
+}

--- a/src/api/community/repository/community-bookmark.repository.ts
+++ b/src/api/community/repository/community-bookmark.repository.ts
@@ -2,10 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 
-import {
-    CommunityBookmark,
-    CommunityBookmarkDocument,
-} from '../../../schema/community-bookmark.schema';
+import { CommunityBookmark, CommunityBookmarkDocument } from '../../../schema/community-bookmark.schema';
 import { CommunityPost, CommunityPostDocument } from '../../../schema/community-post.schema';
 
 @Injectable()
@@ -17,11 +14,7 @@ export class CommunityBookmarkRepository {
         private readonly postModel: Model<CommunityPostDocument>,
     ) {}
 
-    async save(
-        postId: string,
-        userId: string,
-        userModel: 'Adopter' | 'Breeder',
-    ): Promise<{ alreadySaved: boolean }> {
+    async save(postId: string, userId: string, userModel: 'Adopter' | 'Breeder'): Promise<{ alreadySaved: boolean }> {
         if (!Types.ObjectId.isValid(postId)) {
             return { alreadySaved: false };
         }

--- a/src/api/community/swagger/index.ts
+++ b/src/api/community/swagger/index.ts
@@ -9,6 +9,10 @@ import {
 } from '../../../common/decorator/swagger.decorator';
 import { PaginationResponseDto } from '../../../common/dto/pagination/pagination-response.dto';
 import { COMMUNITY_RESPONSE_MESSAGES } from '../constants/community-response-messages';
+import {
+    CommunityBookmarkResponseDto,
+    CommunityUnsaveResponseDto,
+} from '../dto/response/community-bookmark-response.dto';
 import { CommunityPostCardResponseDto } from '../dto/response/community-post-card.dto';
 import { CommunityPostCommentResponseDto } from '../dto/response/community-post-comment.dto';
 import { CommunityPostDeleteResponseDto } from '../dto/response/community-post-delete-response.dto';
@@ -144,5 +148,57 @@ export function ApiDeleteCommunityPostEndpoint() {
             errorResponses: [POST_NOT_FOUND_RESPONSE, POST_FORBIDDEN_RESPONSE],
         }),
         ApiParam({ name: 'postId', description: '게시글 ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
+export function ApiSaveCommunityPostEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '커뮤니티 게시글 저장 (북마크)',
+            description: `
+                Figma 711:59266 — 저장 피드 탭.
+                이미 저장된 경우 saved: false 를 반환하며 오류가 아닌 멱등 처리.
+                저장 시 게시글의 saveCount += 1.
+            `,
+            responseType: CommunityBookmarkResponseDto,
+            successDescription: '게시글 저장 성공',
+            successMessageExample: COMMUNITY_RESPONSE_MESSAGES.saved,
+            errorResponses: [POST_NOT_FOUND_RESPONSE],
+        }),
+        ApiParam({ name: 'postId', description: '게시글 ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
+export function ApiUnsaveCommunityPostEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '커뮤니티 게시글 저장 취소',
+            description: `
+                저장되지 않은 게시글에 취소 요청 시 unsaved: false 반환 (멱등).
+                취소 시 게시글의 saveCount -= 1 (0 미만 방지).
+            `,
+            responseType: CommunityUnsaveResponseDto,
+            successDescription: '게시글 저장 취소 성공',
+            successMessageExample: COMMUNITY_RESPONSE_MESSAGES.unsaved,
+            errorResponses: [POST_NOT_FOUND_RESPONSE],
+        }),
+        ApiParam({ name: 'postId', description: '게시글 ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
+export function ApiGetMySavedCommunityPostsEndpoint() {
+    return applyDecorators(
+        ApiPaginatedEndpoint({
+            summary: '내가 저장한 커뮤니티 게시글 목록',
+            description: `
+                Figma 711:59266 — 저장 피드 탭.
+                저장일 내림차순 정렬. 소프트 삭제된 게시글은 결과에서 제외.
+            `,
+            responseType: PaginationResponseDto,
+            itemType: CommunityPostCardResponseDto,
+            isPublic: false,
+            successDescription: '저장한 게시글 목록 조회 성공',
+            successMessageExample: COMMUNITY_RESPONSE_MESSAGES.savedListRetrieved,
+        }),
     );
 }

--- a/src/api/notification/admin/application/use-cases/send-admin-push.use-case.ts
+++ b/src/api/notification/admin/application/use-cases/send-admin-push.use-case.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
 
 import { NotificationType } from '../../../../../common/enum/user.enum';
 import {
@@ -27,6 +27,8 @@ const FCM_MULTICAST_CHUNK = 500; // FCM sendEachForMulticast 한도
  */
 @Injectable()
 export class SendAdminPushUseCase {
+    private readonly logger = new Logger(SendAdminPushUseCase.name);
+
     constructor(
         @Inject(ADMIN_PUSH_RECIPIENT_READER_PORT)
         private readonly recipientReader: AdminPushRecipientReaderPort,
@@ -51,22 +53,23 @@ export class SendAdminPushUseCase {
             throw new BadRequestException('대상 사용자를 찾을 수 없습니다.');
         }
 
-        // 1) in-app notification doc 생성 (토큰 없는 사용자도 알림 탭에는 보이도록 모든 recipients 대상)
+        // 1) in-app notification doc 일괄 생성 (토큰 없는 사용자도 알림 탭에는 보이도록 모든 recipients 대상)
         let notificationsCreated = 0;
-        for (const r of recipients) {
-            try {
-                await this.notificationCommand.create({
+        try {
+            await this.notificationCommand.createMany(
+                recipients.map((r) => ({
                     userId: r.userId,
                     userRole: r.userRole,
                     type: NotificationType.ADMIN_BROADCAST,
                     title,
                     body,
                     targetUrl: command.targetUrl,
-                });
-                notificationsCreated += 1;
-            } catch {
-                // 단일 사용자 인서트 실패 시 broadcast 전체를 끊지 않음. 카운트 미반영.
-            }
+                })),
+            );
+            notificationsCreated = recipients.length;
+        } catch (err) {
+            // insertMany ordered:false — 일부 실패 시에도 나머지는 삽입됨. 전체 카운트는 보수적으로 0 처리.
+            this.logger.warn(`[sendAdminPush] 일부 in-app notification 생성 실패: ${String(err)}`);
         }
 
         // 2) 토큰 평탄화 + FCM 500개 chunk 발송

--- a/src/api/notification/admin/test/application/use-cases/send-admin-push.use-case.spec.ts
+++ b/src/api/notification/admin/test/application/use-cases/send-admin-push.use-case.spec.ts
@@ -6,7 +6,7 @@ import { AdminPushTargetValidatorService } from '../../../domain/services/admin-
 
 describe('SendAdminPushUseCase', () => {
     const recipientReader = { readRecipients: jest.fn() };
-    const notificationCommand = { create: jest.fn() };
+    const notificationCommand = { create: jest.fn(), createMany: jest.fn() };
     const notificationPush = { sendToTokens: jest.fn() };
 
     const useCase = new SendAdminPushUseCase(
@@ -18,7 +18,7 @@ describe('SendAdminPushUseCase', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        notificationCommand.create.mockResolvedValue({ _id: 'n-1' });
+        notificationCommand.createMany.mockResolvedValue(undefined);
     });
 
     const validCmd = () => ({
@@ -61,7 +61,7 @@ describe('SendAdminPushUseCase', () => {
         expect(notificationPush.sendToTokens).not.toHaveBeenCalled();
     });
 
-    it('정상 — notification doc 생성 + FCM chunk 발송 + 카운트 집계', async () => {
+    it('정상 — notification doc 일괄 생성 + FCM chunk 발송 + 카운트 집계', async () => {
         // 700 토큰 → 500 + 200 두 chunk
         const recipients = [
             { userId: 'a-1', userRole: 'adopter' as const, tokens: Array.from({ length: 500 }, (_, i) => `t-${i}`) },
@@ -86,11 +86,16 @@ describe('SendAdminPushUseCase', () => {
 
         const result = await useCase.execute(validCmd());
 
-        expect(notificationCommand.create).toHaveBeenCalledTimes(2);
-        const firstCreate = notificationCommand.create.mock.calls[0][0];
-        expect(firstCreate.type).toBe(NotificationType.ADMIN_BROADCAST);
-        expect(firstCreate.title).toBe('공지 제목');
-        expect(firstCreate.body).toBe('공지 본문');
+        // createMany를 한 번에 모든 수신자 command 배열로 호출
+        expect(notificationCommand.createMany).toHaveBeenCalledTimes(1);
+        const commands = notificationCommand.createMany.mock.calls[0][0];
+        expect(commands).toHaveLength(2);
+        expect(commands[0]).toMatchObject({
+            userId: 'a-1',
+            type: NotificationType.ADMIN_BROADCAST,
+            title: '공지 제목',
+            body: '공지 본문',
+        });
 
         expect(notificationPush.sendToTokens).toHaveBeenCalledTimes(2);
         expect(notificationPush.sendToTokens.mock.calls[0][0]).toHaveLength(500);
@@ -104,13 +109,13 @@ describe('SendAdminPushUseCase', () => {
         expect(result.invalidTokens).toBe(4);
     });
 
-    it('한 사용자의 notification create 실패해도 broadcast 중단 안 됨 (개별 실패는 카운트만 미반영)', async () => {
+    it('createMany 실패 시 경고 로그 후 broadcast 계속 진행, notificationsCreated=0', async () => {
         const recipients = [
             { userId: 'a-1', userRole: 'adopter' as const, tokens: ['t-1'] },
             { userId: 'a-2', userRole: 'adopter' as const, tokens: ['t-2'] },
         ];
         recipientReader.readRecipients.mockResolvedValueOnce(recipients);
-        notificationCommand.create.mockRejectedValueOnce(new Error('db blip')).mockResolvedValueOnce({ _id: 'n-2' });
+        notificationCommand.createMany.mockRejectedValueOnce(new Error('bulk write error'));
         notificationPush.sendToTokens.mockResolvedValueOnce([
             { token: 't-1', success: true, invalidToken: false },
             { token: 't-2', success: true, invalidToken: false },
@@ -119,7 +124,8 @@ describe('SendAdminPushUseCase', () => {
         const result = await useCase.execute(validCmd());
 
         expect(result.recipients).toBe(2);
-        expect(result.notificationsCreated).toBe(1);
+        // createMany 전체 실패 → notificationsCreated 보수적으로 0
+        expect(result.notificationsCreated).toBe(0);
         expect(result.pushTokensTargeted).toBe(2);
         expect(result.pushSuccess).toBe(2);
     });

--- a/src/api/notification/application/ports/notification-command.port.ts
+++ b/src/api/notification/application/ports/notification-command.port.ts
@@ -19,4 +19,5 @@ export interface NotificationCreateCommand {
 
 export interface NotificationCommandPort {
     create(command: NotificationCreateCommand): Promise<NotificationDocumentRecord>;
+    createMany(commands: NotificationCreateCommand[]): Promise<void>;
 }

--- a/src/api/notification/application/types/notification-email-preview-command.type.ts
+++ b/src/api/notification/application/types/notification-email-preview-command.type.ts
@@ -1,0 +1,18 @@
+export interface BreederApprovalEmailPreviewCommand {
+    email: string;
+    breederName: string;
+}
+
+export interface BreederRejectionEmailPreviewCommand extends BreederApprovalEmailPreviewCommand {
+    rejectionReasons: string[];
+}
+
+export type NewApplicationEmailPreviewCommand = BreederApprovalEmailPreviewCommand;
+export type DocumentReminderEmailPreviewCommand = BreederApprovalEmailPreviewCommand;
+export type NewReviewEmailPreviewCommand = BreederApprovalEmailPreviewCommand;
+
+export interface ApplicationConfirmationEmailPreviewCommand {
+    email: string;
+    applicantName: string;
+    breederName: string;
+}

--- a/src/api/notification/application/use-cases/preview-application-confirmation-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-application-confirmation-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { ApplicationConfirmationEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { ApplicationConfirmationEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,19 +13,19 @@ export class PreviewApplicationConfirmationEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: ApplicationConfirmationEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(command: ApplicationConfirmationEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getApplicationConfirmationTemplate(
-            request.applicantName,
-            request.breederName,
+            command.applicantName,
+            command.breederName,
         );
         const emailData: EmailData = {
-            to: request.email,
+            to: command.email,
             subject: template.subject,
             html: template.html,
         };
 
         return {
-            recipient: request.email,
+            recipient: command.email,
             subject: template.subject,
             preview: template.html,
             sent: this.sendNotificationEmailUseCase.execute(emailData),

--- a/src/api/notification/application/use-cases/preview-breeder-approval-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-breeder-approval-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { BreederApprovalEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { BreederApprovalEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,7 +13,7 @@ export class PreviewBreederApprovalEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: BreederApprovalEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(request: BreederApprovalEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getBreederApprovalTemplate(request.breederName);
         const emailData: EmailData = {
             to: request.email,

--- a/src/api/notification/application/use-cases/preview-breeder-rejection-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-breeder-rejection-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { BreederRejectionEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { BreederRejectionEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,7 +13,7 @@ export class PreviewBreederRejectionEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: BreederRejectionEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(request: BreederRejectionEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getBreederRejectionTemplate(
             request.breederName,
             request.rejectionReasons,

--- a/src/api/notification/application/use-cases/preview-document-reminder-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-document-reminder-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { DocumentReminderEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { DocumentReminderEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,7 +13,7 @@ export class PreviewDocumentReminderEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: DocumentReminderEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(request: DocumentReminderEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getDocumentReminderTemplate(request.breederName);
         const emailData: EmailData = {
             to: request.email,

--- a/src/api/notification/application/use-cases/preview-new-application-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-new-application-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { NewApplicationEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { NewApplicationEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,7 +13,7 @@ export class PreviewNewApplicationEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: NewApplicationEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(request: NewApplicationEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getNewApplicationTemplate(request.breederName);
         const emailData: EmailData = {
             to: request.email,

--- a/src/api/notification/application/use-cases/preview-new-review-email.use-case.ts
+++ b/src/api/notification/application/use-cases/preview-new-review-email.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { EmailData } from '../../builder/notification.builder';
-import { NewReviewEmailPreviewRequestDto } from '../../dto/request/notification-email-preview-request.dto';
+import type { NewReviewEmailPreviewCommand } from '../types/notification-email-preview-command.type';
 import { NotificationEmailPreviewResponseDto } from '../../dto/response/notification-email-preview-response.dto';
 import { NotificationEmailPreviewTemplateService } from '../services/notification-email-preview-template.service';
 import { SendNotificationEmailUseCase } from './send-notification-email.use-case';
@@ -13,7 +13,7 @@ export class PreviewNewReviewEmailUseCase {
         private readonly sendNotificationEmailUseCase: SendNotificationEmailUseCase,
     ) {}
 
-    execute(request: NewReviewEmailPreviewRequestDto): NotificationEmailPreviewResponseDto {
+    execute(request: NewReviewEmailPreviewCommand): NotificationEmailPreviewResponseDto {
         const template = this.notificationEmailPreviewTemplateService.getNewReviewTemplate(request.breederName);
         const emailData: EmailData = {
             to: request.email,

--- a/src/api/notification/infrastructure/notification-mongoose-command.adapter.ts
+++ b/src/api/notification/infrastructure/notification-mongoose-command.adapter.ts
@@ -10,4 +10,8 @@ export class NotificationMongooseCommandAdapter implements NotificationCommandPo
     async create(command: NotificationCreateCommand): Promise<NotificationDocumentRecord> {
         return this.notificationRepository.create(command);
     }
+
+    async createMany(commands: NotificationCreateCommand[]): Promise<void> {
+        return this.notificationRepository.createMany(commands);
+    }
 }

--- a/src/api/notification/repository/notification.repository.ts
+++ b/src/api/notification/repository/notification.repository.ts
@@ -11,6 +11,23 @@ import type { NotificationDocumentRecord } from '../types/notification-record.ty
 export class NotificationRepository {
     constructor(@InjectModel(Notification.name) private readonly notificationModel: Model<Notification>) {}
 
+    async createMany(commands: NotificationCreateCommand[]): Promise<void> {
+        if (commands.length === 0) return;
+        await this.notificationModel.insertMany(
+            commands.map((c) => ({
+                userId: c.userId,
+                userRole: c.userRole,
+                type: c.type,
+                title: c.title,
+                body: c.body,
+                metadata: c.metadata,
+                targetUrl: c.targetUrl,
+                isRead: c.isRead ?? false,
+            })),
+            { ordered: false }, // 일부 실패해도 나머지 계속 삽입
+        );
+    }
+
     async create(command: NotificationCreateCommand): Promise<NotificationDocumentRecord> {
         const notification = new this.notificationModel({
             userId: command.userId,

--- a/src/api/platform/admin/application/types/system-health.type.ts
+++ b/src/api/platform/admin/application/types/system-health.type.ts
@@ -1,0 +1,3 @@
+export interface SystemHealthFilterCommand {
+    periodHours?: number;
+}

--- a/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
+++ b/src/api/platform/admin/application/use-cases/get-system-health.use-case.ts
@@ -6,7 +6,7 @@ import { LOKI_QUERY_PORT } from '../ports/loki-query.port';
 import type { ILokiQueryPort } from '../ports/loki-query.port';
 import { LogCategorizerService } from '../../domain/services/log-categorizer.service';
 import type { CategorizationResult } from '../../domain/services/log-categorizer.service';
-import { SystemHealthFilterRequestDto } from '../../dto/request/system-health-filter-request.dto';
+import type { SystemHealthFilterCommand } from '../types/system-health.type';
 
 /**
  * 시스템 헬스 조회 Use Case
@@ -35,7 +35,7 @@ export class GetSystemHealthUseCase {
      */
     async execute(
         adminId: string,
-        filter: SystemHealthFilterRequestDto,
+        filter: SystemHealthFilterCommand,
         now: Date = new Date(),
     ): Promise<CategorizationResult> {
         await this.verifyAdminPermission(adminId);

--- a/src/api/profile/application/ports/profile-follow.port.ts
+++ b/src/api/profile/application/ports/profile-follow.port.ts
@@ -1,0 +1,20 @@
+export const PROFILE_FOLLOW_PORT = Symbol('PROFILE_FOLLOW_PORT');
+
+export interface ProfileFollowPort {
+    /**
+     * 팔로우. 이미 팔로우 중이면 alreadyFollowing: true (멱등).
+     * 새 팔로우 시 followee 의 followerCount += 1.
+     */
+    follow(followerId: string, followeeId: string): Promise<{ alreadyFollowing: boolean }>;
+
+    /**
+     * 팔로우 취소. 팔로우 중이 아니면 wasFollowing: false (멱등).
+     * 취소 시 followee 의 followerCount -= 1 (0 미만 방지).
+     */
+    unfollow(followerId: string, followeeId: string): Promise<{ wasFollowing: boolean }>;
+
+    /**
+     * followerId 가 followeeId 를 현재 팔로우 중인지 확인.
+     */
+    isFollowing(followerId: string, followeeId: string): Promise<boolean>;
+}

--- a/src/api/profile/application/use-cases/follow-user.use-case.ts
+++ b/src/api/profile/application/use-cases/follow-user.use-case.ts
@@ -1,0 +1,27 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+
+import { PROFILE_FOLLOW_PORT, type ProfileFollowPort } from '../ports/profile-follow.port';
+import { PROFILE_READER_PORT, type ProfileReaderPort } from '../ports/profile-reader.port';
+
+@Injectable()
+export class FollowUserUseCase {
+    constructor(
+        @Inject(PROFILE_READER_PORT)
+        private readonly reader: ProfileReaderPort,
+        @Inject(PROFILE_FOLLOW_PORT)
+        private readonly follow: ProfileFollowPort,
+    ) {}
+
+    async execute(followerId: string, followeeId: string): Promise<{ alreadyFollowing: boolean }> {
+        if (followerId === followeeId) {
+            throw new BadRequestException('자기 자신을 팔로우할 수 없습니다.');
+        }
+
+        const target = await this.reader.readAdopter(followeeId);
+        if (!target) {
+            throw new BadRequestException('해당 사용자를 찾을 수 없습니다.');
+        }
+
+        return this.follow.follow(followerId, followeeId);
+    }
+}

--- a/src/api/profile/application/use-cases/get-adopter-profile.use-case.ts
+++ b/src/api/profile/application/use-cases/get-adopter-profile.use-case.ts
@@ -2,25 +2,31 @@ import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 import { ProfileMapperService } from '../../domain/services/profile-mapper.service';
 import { AdopterPublicProfileResponseDto } from '../../dto/response/adopter-profile-response.dto';
+import { PROFILE_FOLLOW_PORT, type ProfileFollowPort } from '../ports/profile-follow.port';
 import { PROFILE_READER_PORT, type ProfileReaderPort } from '../ports/profile-reader.port';
 
 /**
  * GET /v2/profile/users/:userId — 다른 입양자의 공개 프로필 (유저홈).
- * follow 시스템 미구현이므로 isFollowing 은 항상 false.
  */
 @Injectable()
 export class GetAdopterProfileUseCase {
     constructor(
         @Inject(PROFILE_READER_PORT)
         private readonly reader: ProfileReaderPort,
+        @Inject(PROFILE_FOLLOW_PORT)
+        private readonly follow: ProfileFollowPort,
         private readonly mapper: ProfileMapperService,
     ) {}
 
-    async execute(targetUserId: string, _viewerUserId?: string): Promise<AdopterPublicProfileResponseDto> {
+    async execute(targetUserId: string, viewerUserId?: string): Promise<AdopterPublicProfileResponseDto> {
         const adopter = await this.reader.readAdopter(targetUserId);
         if (!adopter) throw new BadRequestException('입양자 정보를 찾을 수 없습니다.');
 
-        const isFollowing = false; // 입양자→입양자 follow 시스템 도입 시 viewerUserId 활용
+        const isFollowing =
+            viewerUserId && viewerUserId !== targetUserId
+                ? await this.follow.isFollowing(viewerUserId, targetUserId)
+                : false;
+
         return this.mapper.toAdopterPublicDto(adopter, isFollowing);
     }
 }

--- a/src/api/profile/application/use-cases/unfollow-user.use-case.ts
+++ b/src/api/profile/application/use-cases/unfollow-user.use-case.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { PROFILE_FOLLOW_PORT, type ProfileFollowPort } from '../ports/profile-follow.port';
+
+@Injectable()
+export class UnfollowUserUseCase {
+    constructor(
+        @Inject(PROFILE_FOLLOW_PORT)
+        private readonly follow: ProfileFollowPort,
+    ) {}
+
+    execute(followerId: string, followeeId: string): Promise<{ wasFollowing: boolean }> {
+        return this.follow.unfollow(followerId, followeeId);
+    }
+}

--- a/src/api/profile/constants/profile-response-messages.ts
+++ b/src/api/profile/constants/profile-response-messages.ts
@@ -4,4 +4,6 @@ export const PROFILE_RESPONSE_MESSAGES = {
     adopterRetrieved: '입양자 프로필 조회 성공',
     breederRetrieved: '브리더 프로필 조회 성공',
     favoriteBreedersRetrieved: '즐겨찾는 브리더 목록 조회 성공',
+    followed: '팔로우되었습니다.',
+    unfollowed: '팔로우가 취소되었습니다.',
 } as const;

--- a/src/api/profile/controller/profile-follow.controller.ts
+++ b/src/api/profile/controller/profile-follow.controller.ts
@@ -1,0 +1,47 @@
+import { Delete, Param, Post } from '@nestjs/common';
+
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { FollowUserUseCase } from '../application/use-cases/follow-user.use-case';
+import { UnfollowUserUseCase } from '../application/use-cases/unfollow-user.use-case';
+import { PROFILE_RESPONSE_MESSAGES } from '../constants/profile-response-messages';
+import { ProfileMeController } from '../decorator/profile-protected-controller.decorator';
+import type { FollowResponseDto, UnfollowResponseDto } from '../dto/response/follow-response.dto';
+import { ApiFollowUserEndpoint, ApiUnfollowUserEndpoint } from '../swagger';
+
+/**
+ * 팔로우/언팔로우 — JWT 필수, 입양자/브리더 모두 사용 가능 (Figma 678:46565).
+ */
+@ProfileMeController()
+export class ProfileFollowController {
+    constructor(
+        private readonly followUserUseCase: FollowUserUseCase,
+        private readonly unfollowUserUseCase: UnfollowUserUseCase,
+    ) {}
+
+    @Post('users/:userId/follow')
+    @ApiFollowUserEndpoint()
+    async follow(
+        @Param('userId') followeeId: string,
+        @CurrentUser('userId') followerId: string,
+    ): Promise<ApiResponseDto<FollowResponseDto>> {
+        const { alreadyFollowing } = await this.followUserUseCase.execute(followerId, followeeId);
+        return ApiResponseDto.success(
+            { followeeId, followed: !alreadyFollowing },
+            PROFILE_RESPONSE_MESSAGES.followed,
+        );
+    }
+
+    @Delete('users/:userId/follow')
+    @ApiUnfollowUserEndpoint()
+    async unfollow(
+        @Param('userId') followeeId: string,
+        @CurrentUser('userId') followerId: string,
+    ): Promise<ApiResponseDto<UnfollowResponseDto>> {
+        const { wasFollowing } = await this.unfollowUserUseCase.execute(followerId, followeeId);
+        return ApiResponseDto.success(
+            { followeeId, unfollowed: wasFollowing },
+            PROFILE_RESPONSE_MESSAGES.unfollowed,
+        );
+    }
+}

--- a/src/api/profile/controller/profile-follow.controller.ts
+++ b/src/api/profile/controller/profile-follow.controller.ts
@@ -26,10 +26,7 @@ export class ProfileFollowController {
         @CurrentUser('userId') followerId: string,
     ): Promise<ApiResponseDto<FollowResponseDto>> {
         const { alreadyFollowing } = await this.followUserUseCase.execute(followerId, followeeId);
-        return ApiResponseDto.success(
-            { followeeId, followed: !alreadyFollowing },
-            PROFILE_RESPONSE_MESSAGES.followed,
-        );
+        return ApiResponseDto.success({ followeeId, followed: !alreadyFollowing }, PROFILE_RESPONSE_MESSAGES.followed);
     }
 
     @Delete('users/:userId/follow')
@@ -39,9 +36,6 @@ export class ProfileFollowController {
         @CurrentUser('userId') followerId: string,
     ): Promise<ApiResponseDto<UnfollowResponseDto>> {
         const { wasFollowing } = await this.unfollowUserUseCase.execute(followerId, followeeId);
-        return ApiResponseDto.success(
-            { followeeId, unfollowed: wasFollowing },
-            PROFILE_RESPONSE_MESSAGES.unfollowed,
-        );
+        return ApiResponseDto.success({ followeeId, unfollowed: wasFollowing }, PROFILE_RESPONSE_MESSAGES.unfollowed);
     }
 }

--- a/src/api/profile/dto/response/follow-response.dto.ts
+++ b/src/api/profile/dto/response/follow-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FollowResponseDto {
+    @ApiProperty({ description: '팔로우 대상 사용자 ID', example: '507f1f77bcf86cd799439011' })
+    followeeId: string;
+
+    @ApiProperty({ description: '팔로우 완료 여부 (false: 이미 팔로우 중 — 멱등)', example: true })
+    followed: boolean;
+}
+
+export class UnfollowResponseDto {
+    @ApiProperty({ description: '팔로우 취소 대상 사용자 ID', example: '507f1f77bcf86cd799439011' })
+    followeeId: string;
+
+    @ApiProperty({ description: '팔로우 취소 완료 여부 (false: 팔로우 중이 아니었음 — 멱등)', example: true })
+    unfollowed: boolean;
+}

--- a/src/api/profile/infrastructure/profile-follow-mongoose.adapter.ts
+++ b/src/api/profile/infrastructure/profile-follow-mongoose.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+import type { ProfileFollowPort } from '../application/ports/profile-follow.port';
+import { ProfileFollowRepository } from '../repository/profile-follow.repository';
+
+@Injectable()
+export class ProfileFollowMongooseAdapter implements ProfileFollowPort {
+    constructor(private readonly repository: ProfileFollowRepository) {}
+
+    follow(followerId: string, followeeId: string): Promise<{ alreadyFollowing: boolean }> {
+        return this.repository.follow(followerId, followeeId);
+    }
+
+    unfollow(followerId: string, followeeId: string): Promise<{ wasFollowing: boolean }> {
+        return this.repository.unfollow(followerId, followeeId);
+    }
+
+    isFollowing(followerId: string, followeeId: string): Promise<boolean> {
+        return this.repository.isFollowing(followerId, followeeId);
+    }
+}

--- a/src/api/profile/profile.module-definition.ts
+++ b/src/api/profile/profile.module-definition.ts
@@ -4,30 +4,38 @@ import { StorageModule } from '../../common/storage/storage.module';
 import { Adopter, AdopterSchema } from '../../schema/adopter.schema';
 import { AvailablePet, AvailablePetSchema } from '../../schema/available-pet.schema';
 import { Breeder, BreederSchema } from '../../schema/breeder.schema';
+import { UserFollow, UserFollowSchema } from '../../schema/user-follow.schema';
 
 import { PROFILE_ASSET_URL_PORT } from './application/ports/profile-asset-url.port';
+import { PROFILE_FOLLOW_PORT } from './application/ports/profile-follow.port';
 import { PROFILE_READER_PORT } from './application/ports/profile-reader.port';
 import { PROFILE_WRITER_PORT } from './application/ports/profile-writer.port';
 import { GetAdopterProfileUseCase } from './application/use-cases/get-adopter-profile.use-case';
 import { GetBreederProfileUseCase } from './application/use-cases/get-breeder-profile.use-case';
 import { GetMyFavoriteBreedersUseCase } from './application/use-cases/get-my-favorite-breeders.use-case';
 import { GetMyProfileUseCase } from './application/use-cases/get-my-profile.use-case';
+import { FollowUserUseCase } from './application/use-cases/follow-user.use-case';
+import { UnfollowUserUseCase } from './application/use-cases/unfollow-user.use-case';
 import { UpdateMyProfileUseCase } from './application/use-cases/update-my-profile.use-case';
 import { ProfileMapperService } from './domain/services/profile-mapper.service';
 import { ProfileAssetUrlStorageAdapter } from './infrastructure/profile-asset-url-storage.adapter';
+import { ProfileFollowMongooseAdapter } from './infrastructure/profile-follow-mongoose.adapter';
 import { ProfileReaderMongooseAdapter } from './infrastructure/profile-reader-mongoose.adapter';
 import { ProfileWriterMongooseAdapter } from './infrastructure/profile-writer-mongoose.adapter';
 import {
     ProfileFavoriteBreedersController,
     ProfileMeController,
 } from './controller/profile-me.controller';
+import { ProfileFollowController } from './controller/profile-follow.controller';
 import { ProfilePublicController } from './controller/profile-public.controller';
+import { ProfileFollowRepository } from './repository/profile-follow.repository';
 import { ProfileRepository } from './repository/profile.repository';
 
 const SCHEMA_IMPORTS = MongooseModule.forFeature([
     { name: Adopter.name, schema: AdopterSchema },
     { name: Breeder.name, schema: BreederSchema },
     { name: AvailablePet.name, schema: AvailablePetSchema },
+    { name: UserFollow.name, schema: UserFollowSchema },
 ]);
 
 export const PROFILE_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule];
@@ -36,6 +44,7 @@ export const PROFILE_MODULE_CONTROLLERS = [
     ProfileMeController,
     ProfileFavoriteBreedersController,
     ProfilePublicController,
+    ProfileFollowController,
 ];
 
 const USE_CASE_PROVIDERS = [
@@ -44,21 +53,26 @@ const USE_CASE_PROVIDERS = [
     GetAdopterProfileUseCase,
     GetBreederProfileUseCase,
     GetMyFavoriteBreedersUseCase,
+    FollowUserUseCase,
+    UnfollowUserUseCase,
 ];
 
 const DOMAIN_PROVIDERS = [ProfileMapperService];
 
 const INFRASTRUCTURE_PROVIDERS = [
     ProfileRepository,
+    ProfileFollowRepository,
     ProfileReaderMongooseAdapter,
     ProfileWriterMongooseAdapter,
     ProfileAssetUrlStorageAdapter,
+    ProfileFollowMongooseAdapter,
 ];
 
 const PORT_BINDINGS = [
     { provide: PROFILE_READER_PORT, useExisting: ProfileReaderMongooseAdapter },
     { provide: PROFILE_WRITER_PORT, useExisting: ProfileWriterMongooseAdapter },
     { provide: PROFILE_ASSET_URL_PORT, useExisting: ProfileAssetUrlStorageAdapter },
+    { provide: PROFILE_FOLLOW_PORT, useExisting: ProfileFollowMongooseAdapter },
 ];
 
 export const PROFILE_MODULE_PROVIDERS = [

--- a/src/api/profile/profile.module-definition.ts
+++ b/src/api/profile/profile.module-definition.ts
@@ -22,10 +22,7 @@ import { ProfileAssetUrlStorageAdapter } from './infrastructure/profile-asset-ur
 import { ProfileFollowMongooseAdapter } from './infrastructure/profile-follow-mongoose.adapter';
 import { ProfileReaderMongooseAdapter } from './infrastructure/profile-reader-mongoose.adapter';
 import { ProfileWriterMongooseAdapter } from './infrastructure/profile-writer-mongoose.adapter';
-import {
-    ProfileFavoriteBreedersController,
-    ProfileMeController,
-} from './controller/profile-me.controller';
+import { ProfileFavoriteBreedersController, ProfileMeController } from './controller/profile-me.controller';
 import { ProfileFollowController } from './controller/profile-follow.controller';
 import { ProfilePublicController } from './controller/profile-public.controller';
 import { ProfileFollowRepository } from './repository/profile-follow.repository';

--- a/src/api/profile/repository/profile-follow.repository.ts
+++ b/src/api/profile/repository/profile-follow.repository.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+import { Adopter, AdopterDocument } from '../../../schema/adopter.schema';
+import { UserFollow, UserFollowDocument } from '../../../schema/user-follow.schema';
+
+@Injectable()
+export class ProfileFollowRepository {
+    constructor(
+        @InjectModel(UserFollow.name)
+        private readonly followModel: Model<UserFollowDocument>,
+        @InjectModel(Adopter.name)
+        private readonly adopterModel: Model<AdopterDocument>,
+    ) {}
+
+    async follow(followerId: string, followeeId: string): Promise<{ alreadyFollowing: boolean }> {
+        try {
+            await this.followModel.create({ followerId, followeeId });
+            // followee 의 followerCount 증가 (Adopter 만 팔로우 대상)
+            await this.adopterModel
+                .updateOne({ _id: new Types.ObjectId(followeeId) }, { $inc: { followerCount: 1 } })
+                .exec();
+            return { alreadyFollowing: false };
+        } catch (err: unknown) {
+            if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
+                return { alreadyFollowing: true };
+            }
+            throw err;
+        }
+    }
+
+    async unfollow(followerId: string, followeeId: string): Promise<{ wasFollowing: boolean }> {
+        const result = await this.followModel.deleteOne({ followerId, followeeId }).exec();
+        if (result.deletedCount === 0) {
+            return { wasFollowing: false };
+        }
+
+        // followerCount 0 미만 방지
+        await this.adopterModel
+            .updateOne(
+                { _id: new Types.ObjectId(followeeId), followerCount: { $gt: 0 } },
+                { $inc: { followerCount: -1 } },
+            )
+            .exec();
+
+        return { wasFollowing: true };
+    }
+
+    async isFollowing(followerId: string, followeeId: string): Promise<boolean> {
+        const found = await this.followModel.exists({ followerId, followeeId });
+        return Boolean(found);
+    }
+}

--- a/src/api/profile/repository/profile.repository.ts
+++ b/src/api/profile/repository/profile.repository.ts
@@ -93,9 +93,7 @@ export class ProfileRepository {
             return Boolean(exists);
         }
 
-        const result = await this.adopterModel
-            .updateOne({ _id: new Types.ObjectId(userId) }, { $set })
-            .exec();
+        const result = await this.adopterModel.updateOne({ _id: new Types.ObjectId(userId) }, { $set }).exec();
         return result.matchedCount > 0;
     }
 
@@ -121,9 +119,7 @@ export class ProfileRepository {
             return Boolean(exists);
         }
 
-        const result = await this.breederModel
-            .updateOne({ _id: new Types.ObjectId(breederId) }, { $set })
-            .exec();
+        const result = await this.breederModel.updateOne({ _id: new Types.ObjectId(breederId) }, { $set }).exec();
         return result.matchedCount > 0;
     }
 }

--- a/src/api/profile/swagger/index.ts
+++ b/src/api/profile/swagger/index.ts
@@ -124,7 +124,11 @@ export function ApiFollowUserEndpoint() {
             successDescription: '팔로우 성공',
             successMessageExample: PROFILE_RESPONSE_MESSAGES.followed,
             errorResponses: [
-                { status: 400, description: '대상 없음 / 자기 자신 팔로우', errorExample: '해당 사용자를 찾을 수 없습니다.' },
+                {
+                    status: 400,
+                    description: '대상 없음 / 자기 자신 팔로우',
+                    errorExample: '해당 사용자를 찾을 수 없습니다.',
+                },
             ],
         }),
         ApiParam({ name: 'userId', description: '팔로우할 사용자 ID', example: '507f1f77bcf86cd799439011' }),

--- a/src/api/profile/swagger/index.ts
+++ b/src/api/profile/swagger/index.ts
@@ -12,6 +12,7 @@ import { PROFILE_RESPONSE_MESSAGES } from '../constants/profile-response-message
 import { AdopterPublicProfileResponseDto } from '../dto/response/adopter-profile-response.dto';
 import { BreederPublicProfileResponseDto } from '../dto/response/breeder-profile-response.dto';
 import { FavoriteBreederCardResponseDto } from '../dto/response/favorite-breeder-card.dto';
+import { FollowResponseDto, UnfollowResponseDto } from '../dto/response/follow-response.dto';
 import { MyProfileResponseDto } from '../dto/response/my-profile-response.dto';
 
 const NOT_FOUND_RESPONSE = {
@@ -69,7 +70,7 @@ export function ApiGetAdopterProfileEndpoint() {
     return applyDecorators(
         ApiEndpoint({
             summary: '다른 입양자 프로필 조회 (유저홈)',
-            description: '특정 입양자의 공개 프로필. follow 시스템 미구현이라 isFollowing 은 항상 false.',
+            description: '특정 입양자의 공개 프로필. 로그인 사용자는 isFollowing 이 실제 팔로우 여부로 채워진다.',
             responseType: AdopterPublicProfileResponseDto,
             isPublic: true,
             supportsOptionalAuth: true,
@@ -107,5 +108,38 @@ export function ApiGetMyFavoriteBreedersEndpoint() {
             successDescription: '즐겨찾는 브리더 목록 조회 성공',
             successMessageExample: PROFILE_RESPONSE_MESSAGES.favoriteBreedersRetrieved,
         }),
+    );
+}
+
+export function ApiFollowUserEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '사용자 팔로우 (Figma 678:46565)',
+            description: `
+                입양자 유저홈에서 팔로우. 대상은 입양자(Adopter)만 가능.
+                이미 팔로우 중이면 followed: false 반환 (멱등).
+                자기 자신 팔로우 시 400.
+            `,
+            responseType: FollowResponseDto,
+            successDescription: '팔로우 성공',
+            successMessageExample: PROFILE_RESPONSE_MESSAGES.followed,
+            errorResponses: [
+                { status: 400, description: '대상 없음 / 자기 자신 팔로우', errorExample: '해당 사용자를 찾을 수 없습니다.' },
+            ],
+        }),
+        ApiParam({ name: 'userId', description: '팔로우할 사용자 ID', example: '507f1f77bcf86cd799439011' }),
+    );
+}
+
+export function ApiUnfollowUserEndpoint() {
+    return applyDecorators(
+        ApiEndpoint({
+            summary: '사용자 팔로우 취소',
+            description: '팔로우 중이 아닌 사용자에게 요청 시 unfollowed: false 반환 (멱등).',
+            responseType: UnfollowResponseDto,
+            successDescription: '팔로우 취소 성공',
+            successMessageExample: PROFILE_RESPONSE_MESSAGES.unfollowed,
+        }),
+        ApiParam({ name: 'userId', description: '팔로우 취소할 사용자 ID', example: '507f1f77bcf86cd799439011' }),
     );
 }

--- a/src/api/user/admin/application/types/user-admin-result.type.ts
+++ b/src/api/user/admin/application/types/user-admin-result.type.ts
@@ -23,6 +23,8 @@ export type UserAdminUserManagementItemResult = {
     userId: string;
     userName: string;
     emailAddress: string;
+    nickname?: string;
+    phoneNumber?: string;
     userRole: UserAdminManagedUserRole;
     accountStatus: string;
     lastLoginAt: Date;

--- a/src/api/user/admin/domain/services/user-admin-user-page-assembler.service.ts
+++ b/src/api/user/admin/domain/services/user-admin-user-page-assembler.service.ts
@@ -17,6 +17,8 @@ export class UserAdminUserPageAssemblerService {
                 userId: user.id,
                 userName: user.nickname || user.name || '',
                 emailAddress: user.emailAddress,
+                nickname: user.nickname,
+                phoneNumber: user.phoneNumber,
                 userRole: user.role,
                 accountStatus: user.accountStatus,
                 lastLoginAt: user.lastLoginAt as Date,

--- a/src/api/user/admin/dto/response/user-management-response.dto.ts
+++ b/src/api/user/admin/dto/response/user-management-response.dto.ts
@@ -65,6 +65,28 @@ export class UserManagementResponseDto {
     emailAddress: string;
 
     /**
+     * 사용자 닉네임 (입양자만 보유, 브리더는 null/empty)
+     * @example "퐁이팜"
+     */
+    @ApiProperty({
+        description: '사용자 닉네임 (없으면 빈 문자열)',
+        example: '퐁이팜',
+        required: false,
+    })
+    nickname?: string;
+
+    /**
+     * 휴대전화 번호 (E.164 또는 010-xxxx-xxxx 등 가공된 표현)
+     * @example "01012345678"
+     */
+    @ApiProperty({
+        description: '휴대전화 번호 (없으면 빈 문자열)',
+        example: '01012345678',
+        required: false,
+    })
+    phoneNumber?: string;
+
+    /**
      * 사용자 역할 (입양자/브리더)
      * @example "adopter"
      */

--- a/src/common/strategy/infrastructure/jwt-user-status-mongoose.adapter.ts
+++ b/src/common/strategy/infrastructure/jwt-user-status-mongoose.adapter.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+import { Adopter, AdopterDocument } from '../../../schema/adopter.schema';
+import { Breeder, BreederDocument } from '../../../schema/breeder.schema';
+import type { JwtUserStatusPort } from '../ports/jwt-user-status.port';
+
+@Injectable()
+export class JwtUserStatusMongooseAdapter implements JwtUserStatusPort {
+    constructor(
+        @InjectModel(Adopter.name) private readonly adopterModel: Model<AdopterDocument>,
+        @InjectModel(Breeder.name) private readonly breederModel: Model<BreederDocument>,
+    ) {}
+
+    async findAccountStatus(userId: string, role: 'adopter' | 'breeder'): Promise<string | undefined> {
+        if (role === 'adopter') {
+            const adopter = await this.adopterModel.findById(userId).select('accountStatus').lean().exec();
+            return adopter?.accountStatus;
+        }
+        const breeder = await this.breederModel.findById(userId).select('accountStatus').lean().exec();
+        return breeder?.accountStatus;
+    }
+}

--- a/src/common/strategy/jwt.strategy.ts
+++ b/src/common/strategy/jwt.strategy.ts
@@ -1,15 +1,11 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
 import { Request } from 'express';
 
 import { DomainAuthenticationError } from '../error/domain.error';
-
-import { Adopter, AdopterDocument } from '../../schema/adopter.schema';
-import { Breeder, BreederDocument } from '../../schema/breeder.schema';
+import { JWT_USER_STATUS_PORT, type JwtUserStatusPort } from './ports/jwt-user-status.port';
 import type { AuthenticatedRequestUser, JwtPayloadClaims } from '../types/authenticated-request-user.type';
 
 /**
@@ -23,8 +19,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
     constructor(
         configService: ConfigService,
-        @InjectModel(Adopter.name) private adopterModel: Model<AdopterDocument>,
-        @InjectModel(Breeder.name) private breederModel: Model<BreederDocument>,
+        @Inject(JWT_USER_STATUS_PORT) private readonly userStatusPort: JwtUserStatusPort,
     ) {
         const jwtSecret = configService.get<string>('JWT_SECRET') || 'fallback-secret';
 
@@ -52,14 +47,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
      * 탈퇴된 계정인 경우 도메인 인증 예외를 발생시킵니다.
      */
     async validate(payload: JwtPayloadClaims): Promise<AuthenticatedRequestUser> {
-        // 사용자 조회 및 탈퇴 여부 확인
         let accountStatus: string | undefined;
-        if (payload.role === 'adopter') {
-            const adopter = await this.adopterModel.findById(payload.sub).select('accountStatus').lean().exec();
-            accountStatus = adopter?.accountStatus;
-        } else if (payload.role === 'breeder') {
-            const breeder = await this.breederModel.findById(payload.sub).select('accountStatus').lean().exec();
-            accountStatus = breeder?.accountStatus;
+        if (payload.role === 'adopter' || payload.role === 'breeder') {
+            accountStatus = await this.userStatusPort.findAccountStatus(payload.sub, payload.role);
         }
 
         // 탈퇴된 계정인 경우 인증 실패

--- a/src/common/strategy/ports/jwt-user-status.port.ts
+++ b/src/common/strategy/ports/jwt-user-status.port.ts
@@ -1,0 +1,5 @@
+export const JWT_USER_STATUS_PORT = Symbol('JWT_USER_STATUS_PORT');
+
+export interface JwtUserStatusPort {
+    findAccountStatus(userId: string, role: 'adopter' | 'breeder'): Promise<string | undefined>;
+}

--- a/src/common/strategy/test/jwt.strategy.spec.ts
+++ b/src/common/strategy/test/jwt.strategy.spec.ts
@@ -1,42 +1,21 @@
 import { DomainAuthenticationError } from '../../../common/error/domain.error';
 import { JwtStrategy } from '../../../common/strategy/jwt.strategy';
+import type { JwtUserStatusPort } from '../../../common/strategy/ports/jwt-user-status.port';
 
 describe('JwtStrategy', () => {
-    const createFindByIdQuery = (value: unknown) => ({
-        select: jest.fn().mockReturnValue({
-            lean: jest.fn().mockReturnValue({
-                exec: jest.fn().mockResolvedValue(value),
-            }),
-        }),
-    });
-
-    const createStrategy = () => {
+    const createStrategy = (userStatusPort: jest.Mocked<JwtUserStatusPort>) => {
         const configService = {
             get: jest.fn().mockReturnValue('jwt-secret'),
         };
-        const adopterModel = {
-            findById: jest.fn(),
-        };
-        const breederModel = {
-            findById: jest.fn(),
-        };
 
-        const strategy = new JwtStrategy(configService as never, adopterModel as never, breederModel as never);
-
-        return {
-            strategy,
-            adopterModel,
-            breederModel,
-        };
+        return new JwtStrategy(configService as never, userStatusPort);
     };
 
     it('탈퇴한 adopter는 DomainAuthenticationError를 던진다', async () => {
-        const { strategy, adopterModel } = createStrategy();
-        adopterModel.findById.mockReturnValue(
-            createFindByIdQuery({
-                accountStatus: 'deleted',
-            }),
-        );
+        const userStatusPort: jest.Mocked<JwtUserStatusPort> = {
+            findAccountStatus: jest.fn().mockResolvedValue('deleted'),
+        };
+        const strategy = createStrategy(userStatusPort);
 
         await expect(
             strategy.validate({
@@ -45,15 +24,15 @@ describe('JwtStrategy', () => {
                 role: 'adopter',
             }),
         ).rejects.toThrow(new DomainAuthenticationError('이미 탈퇴된 계정입니다.'));
+
+        expect(userStatusPort.findAccountStatus).toHaveBeenCalledWith('adopter-id', 'adopter');
     });
 
     it('정상 breeder는 인증 사용자 정보를 반환한다', async () => {
-        const { strategy, breederModel } = createStrategy();
-        breederModel.findById.mockReturnValue(
-            createFindByIdQuery({
-                accountStatus: 'active',
-            }),
-        );
+        const userStatusPort: jest.Mocked<JwtUserStatusPort> = {
+            findAccountStatus: jest.fn().mockResolvedValue('active'),
+        };
+        const strategy = createStrategy(userStatusPort);
 
         await expect(
             strategy.validate({

--- a/src/schema/community-bookmark.schema.ts
+++ b/src/schema/community-bookmark.schema.ts
@@ -1,0 +1,33 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type CommunityBookmarkDocument = CommunityBookmark &
+    Document & {
+        _id: Types.ObjectId;
+        createdAt: Date;
+    };
+
+/**
+ * v2 커뮤니티 게시글 저장(북마크) — 저장 피드 탭 (Figma 711:59266).
+ * 사용자 1명이 게시글 1개에 최대 1회 저장 가능 (복합 유니크 인덱스).
+ * 저장/취소 시 community_posts.saveCount 를 원자적으로 갱신한다.
+ */
+@Schema({ timestamps: { createdAt: true, updatedAt: false }, collection: 'community_bookmarks' })
+export class CommunityBookmark {
+    @Prop({ type: Types.ObjectId, ref: 'CommunityPost', required: true, index: true })
+    postId: Types.ObjectId;
+
+    /** 사용자 ObjectId 문자열 (Adopter/Breeder 공용) */
+    @Prop({ required: true, index: true })
+    userId: string;
+
+    @Prop({ type: String, enum: ['Adopter', 'Breeder'], required: true })
+    userModel: 'Adopter' | 'Breeder';
+
+    createdAt: Date;
+}
+
+export const CommunityBookmarkSchema = SchemaFactory.createForClass(CommunityBookmark);
+
+CommunityBookmarkSchema.index({ postId: 1, userId: 1 }, { unique: true });
+CommunityBookmarkSchema.index({ userId: 1, createdAt: -1 });

--- a/src/schema/user-follow.schema.ts
+++ b/src/schema/user-follow.schema.ts
@@ -1,0 +1,31 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type UserFollowDocument = UserFollow &
+    Document & {
+        _id: Types.ObjectId;
+        createdAt: Date;
+    };
+
+/**
+ * 팔로우 관계 (Figma 678:46565).
+ * 팔로워(follower) → 팔로위(followee) 방향.
+ * 팔로우 발생 시 followee 의 Adopter.followerCount 를 원자적으로 갱신한다.
+ */
+@Schema({ timestamps: { createdAt: true, updatedAt: false }, collection: 'user_follows' })
+export class UserFollow {
+    /** 팔로우를 시작한 사용자 ID (ObjectId 문자열) */
+    @Prop({ required: true, index: true })
+    followerId: string;
+
+    /** 팔로우 대상 사용자 ID (ObjectId 문자열, Adopter) */
+    @Prop({ required: true, index: true })
+    followeeId: string;
+
+    createdAt: Date;
+}
+
+export const UserFollowSchema = SchemaFactory.createForClass(UserFollow);
+
+/** 같은 쌍 중복 방지 */
+UserFollowSchema.index({ followerId: 1, followeeId: 1 }, { unique: true });


### PR DESCRIPTION
## Summary

- **adoption**: 입양 목록 `keyword` 검색 파라미터 추가 — 이름·품종 부분 일치 (Figma 678:43115)
- **community**: 게시글 저장(북마크) 기능 구현 — 저장 피드 탭 (Figma 711:59266)
  - `POST/DELETE /v2/community/posts/:postId/bookmark`
  - `GET /v2/community/posts/me/bookmarks` (페이지네이션)
  - 저장/취소 시 `saveCount` 원자 갱신, 멱등 처리
- **profile**: 사용자 팔로우 기능 구현 (Figma 678:46565)
  - `POST/DELETE /v2/profile/users/:userId/follow`
  - `GET /v2/profile/users/:userId` 의 `isFollowing` 실제 팔로우 여부 반영
  - 팔로우/취소 시 `followerCount` 원자 갱신

## Test plan

- [ ] `GET /v2/adoption?keyword=말티즈` — 이름·품종에 "말티즈" 포함된 펫만 반환
- [ ] `POST /v2/community/posts/:postId/bookmark` — 저장 후 `saveCount+1`, 재요청 시 `saved: false`
- [ ] `DELETE /v2/community/posts/:postId/bookmark` — 취소 후 `saveCount-1`, 미저장 상태 재요청 시 `unsaved: false`
- [ ] `GET /v2/community/posts/me/bookmarks` — 저장한 게시글 최신순 페이지네이션
- [ ] `POST /v2/profile/users/:userId/follow` — 팔로우 후 `followerCount+1`, 재요청 시 `followed: false`
- [ ] `DELETE /v2/profile/users/:userId/follow` — 취소 후 `followerCount-1`, 미팔로우 상태 재요청 시 `unfollowed: false`
- [ ] `GET /v2/profile/users/:userId` (로그인) — `isFollowing: true` 확인