### PR TITLE
feat(contest): 지난주 TOP 3 조회 API 구현 (#147)

### DIFF
--- a/src/api/contest/application/types/contest-result.type.ts
+++ b/src/api/contest/application/types/contest-result.type.ts
@@ -85,3 +85,12 @@ export interface GetYesterdayTopResult {
     contestId: string;
     ranking: YesterdayTopEntry[];
 }
+
+export interface GetWeeklyTopResult {
+    /** ISO 8601 주차 키 (예: "2026-W21") */
+    weekKey: string;
+    /** 지난주 voteCount 내림차순 TOP 3 항목 */
+    topEntries: ContestEntryItem[];
+    /** 집계 기준 시각 (해당 콘테스트 종료일) */
+    calculatedAt: Date;
+}

--- a/src/api/contest/application/use-cases/get-weekly-top.use-case.ts
+++ b/src/api/contest/application/use-cases/get-weekly-top.use-case.ts
@@ -1,0 +1,75 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { CONTEST_ASSET_URL_PORT, type ContestAssetUrlPort } from '../ports/contest-asset-url.port';
+import { CONTEST_READER_PORT, type ContestEntrySnapshot, type ContestReaderPort } from '../ports/contest-reader.port';
+import type { ContestEntryItem, GetWeeklyTopResult } from '../types/contest-result.type';
+
+@Injectable()
+export class GetWeeklyTopUseCase {
+    constructor(
+        @Inject(CONTEST_READER_PORT)
+        private readonly reader: ContestReaderPort,
+        @Inject(CONTEST_ASSET_URL_PORT)
+        private readonly assetUrl: ContestAssetUrlPort,
+        private readonly logger: CustomLoggerService,
+    ) {}
+
+    async execute(): Promise<GetWeeklyTopResult | null> {
+        this.logger.logStart('getWeeklyTop', '지난주 TOP 3 조회');
+
+        const contest = await this.reader.findLatestEnded();
+        if (!contest) {
+            this.logger.logWarning('getWeeklyTop', '종료된 콘테스트 없음');
+            return null;
+        }
+
+        const topEntries = await this.reader.findTopEntries(contest.id, 3);
+        const entries = await this.resolveEntries(topEntries);
+
+        this.logger.logSuccess('getWeeklyTop', '지난주 TOP 3 조회 완료', { count: entries.length });
+
+        return {
+            weekKey: this.buildWeekKey(contest.endDate),
+            topEntries: entries,
+            calculatedAt: contest.endDate,
+        };
+    }
+
+    private async resolveEntries(snapshots: ContestEntrySnapshot[]): Promise<ContestEntryItem[]> {
+        return Promise.all(
+            snapshots.map(async (entry, index) => {
+                const [photoUrl, profileImageUrl] = await Promise.all([
+                    this.assetUrl.generateSignedUrl(entry.photoFileName),
+                    entry.userProfileImageFileName
+                        ? this.assetUrl.generateSignedUrl(entry.userProfileImageFileName)
+                        : Promise.resolve<string | null>(null),
+                ]);
+
+                return {
+                    id: entry.id,
+                    userId: entry.userId,
+                    userDisplayName: entry.userDisplayName,
+                    userProfileImageUrl: profileImageUrl,
+                    photoUrl,
+                    description: entry.description,
+                    voteCount: entry.voteCount,
+                    rank: entry.rank ?? index + 1,
+                    hasVoted: false,
+                    isMyEntry: false,
+                    createdAt: entry.createdAt,
+                };
+            }),
+        );
+    }
+
+    /** ISO 8601 주차 키 계산 (예: endDate 2026-05-24 → "2026-W21") */
+    private buildWeekKey(date: Date): string {
+        const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        const dayOfWeek = d.getUTCDay() || 7;
+        d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
+        const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+        const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+        return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+    }
+}

--- a/src/api/contest/contest.module-definition.ts
+++ b/src/api/contest/contest.module-definition.ts
@@ -19,12 +19,14 @@ import { GetMyContestEntryUseCase } from './application/use-cases/get-my-contest
 import { GetPreviousRankingUseCase } from './application/use-cases/get-previous-ranking.use-case';
 import { GetHallOfFameUseCase } from './application/use-cases/get-hall-of-fame.use-case';
 import { GetRandomContestEntryUseCase } from './application/use-cases/get-random-contest-entry.use-case';
+import { GetWeeklyTopUseCase } from './application/use-cases/get-weekly-top.use-case';
 import { GetYesterdayTopUseCase } from './application/use-cases/get-yesterday-top.use-case';
 import { ContestCurrentController } from './controller/contest-current.controller';
 import { ContestEntriesController } from './controller/contest-entries.controller';
 import { ContestEntrySubmitController } from './controller/contest-entry-submit.controller';
 import { ContestHallOfFameController } from './controller/contest-hall-of-fame.controller';
 import { ContestRandomEntryController } from './controller/contest-random-entry.controller';
+import { ContestWeeklyTopController } from './controller/contest-weekly-top.controller';
 import { ContestYesterdayTopController } from './controller/contest-yesterday-top.controller';
 import { ContestMeController } from './controller/contest-me.controller';
 import { ContestPreviousRankingController } from './controller/contest-previous-ranking.controller';
@@ -54,6 +56,7 @@ export const CONTEST_MODULE_CONTROLLERS = [
     ContestPreviousRankingController,
     ContestHallOfFameController,
     ContestRandomEntryController,
+    ContestWeeklyTopController,
     ContestYesterdayTopController,
 ];
 
@@ -61,6 +64,7 @@ const USE_CASE_PROVIDERS = [
     GetCurrentContestUseCase,
     GetContestEntriesUseCase,
     GetRandomContestEntryUseCase,
+    GetWeeklyTopUseCase,
     GetYesterdayTopUseCase,
     SubmitContestEntryUseCase,
     VoteContestEntryUseCase,

--- a/src/api/contest/controller/contest-weekly-top.controller.ts
+++ b/src/api/contest/controller/contest-weekly-top.controller.ts
@@ -1,0 +1,22 @@
+import { Get } from '@nestjs/common';
+
+import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { GetWeeklyTopUseCase } from '../application/use-cases/get-weekly-top.use-case';
+import { ContestPublicController } from '../decorator/contest-controller.decorator';
+import { ApiGetWeeklyTopEndpoint } from '../swagger';
+
+/**
+ * 지난주 최종 TOP 3 조회 (홈 화면 명예의 전당 영역 연동용).
+ * GET v2/contest/weekly-top
+ */
+@ContestPublicController()
+export class ContestWeeklyTopController {
+    constructor(private readonly getWeeklyTopUseCase: GetWeeklyTopUseCase) {}
+
+    @Get('weekly-top')
+    @ApiGetWeeklyTopEndpoint()
+    async getWeeklyTop(): Promise<ApiResponseDto<unknown>> {
+        const result = await this.getWeeklyTopUseCase.execute();
+        return ApiResponseDto.success(result, '지난주 TOP 3 조회 완료');
+    }
+}

--- a/src/api/contest/dto/response/contest-weekly-top-response.dto.ts
+++ b/src/api/contest/dto/response/contest-weekly-top-response.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ContestEntryDto } from './contest-entry.dto';
+
+export class ContestWeeklyTopResponseDto {
+    @ApiProperty({ description: 'ISO 8601 주차 키 (예: "2026-W21")', example: '2026-W21' })
+    weekKey: string;
+
+    @ApiProperty({ type: [ContestEntryDto], description: '지난주 voteCount 기준 TOP 3 항목' })
+    topEntries: ContestEntryDto[];
+
+    @ApiProperty({ description: '집계 기준 시각 ISO (해당 콘테스트 종료일)', example: '2026-05-24T23:59:59.000Z' })
+    calculatedAt: string;
+}

--- a/src/api/contest/swagger/index.ts
+++ b/src/api/contest/swagger/index.ts
@@ -15,6 +15,7 @@ import {
     ContestPreviousRankingResponseDto,
 } from '../dto/response/contest-hall-of-fame-response.dto';
 import { ContestRandomEntryResponseDto } from '../dto/response/contest-random-entry-response.dto';
+import { ContestWeeklyTopResponseDto } from '../dto/response/contest-weekly-top-response.dto';
 import { ContestYesterdayTopResponseDto } from '../dto/response/contest-yesterday-top-response.dto';
 
 const TAG = '콘테스트';
@@ -117,5 +118,15 @@ export function ApiGetRandomContestEntryEndpoint() {
 - 투표 가능한 항목 없음: entry: null, alreadyVoted: false
 - 투표 전이므로 voteCount는 항상 null`,
         responseType: ContestRandomEntryResponseDto,
+    });
+}
+
+export function ApiGetWeeklyTopEndpoint() {
+    return ApiEndpoint({
+        summary: '지난주 TOP 3 조회',
+        description:
+            '가장 최근 종료된 콘테스트의 voteCount 기준 TOP 3를 반환합니다. 홈 화면 명예의 전당 영역 연동용. 종료된 콘테스트가 없으면 data: null.',
+        responseType: ContestWeeklyTopResponseDto,
+        isPublic: true,
     });
 }

--- a/src/api/contest/test/e2e/contest.e2e-spec.ts
+++ b/src/api/contest/test/e2e/contest.e2e-spec.ts
@@ -221,6 +221,14 @@ describe('콘테스트 E2E 테스트', () => {
             expect(res.body.data).toBeNull();
         });
 
+        it('GET /weekly-top → data: null', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            expect(res.body.data).toBeNull();
+        });
+
         it('GET /hall-of-fame → 빈 목록', async () => {
             const res = await request(app.getHttpServer())
                 .get('/api/v2/contest/hall-of-fame')
@@ -287,6 +295,16 @@ describe('콘테스트 E2E 테스트', () => {
                 .expect(200);
 
             expect(res.body.data.contest.title).toBe('저번주 명예의 전당');
+        });
+
+        it('GET /weekly-top → 종료 콘테스트 반환, topEntries 빈 배열', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            expect(res.body.data.weekKey).toMatch(/^\d{4}-W\d{2}$/);
+            expect(res.body.data.topEntries).toHaveLength(0);
+            expect(res.body.data.calculatedAt).toBeDefined();
         });
 
         // ─── 참여 (user1) ──────────────────────────────────────────────────
@@ -489,6 +507,62 @@ describe('콘테스트 E2E 테스트', () => {
                     });
                 });
             });
+        });
+    });
+
+    // ── weekly-top: 종료 콘테스트에 항목 있을 때 ────────────────────────────
+
+    describe('종료 콘테스트에 항목 있을 때 — weekly-top', () => {
+        beforeAll(async () => {
+            const { contestId } = await seedContest(app, {
+                title: '지난주 명예의 전당',
+                status: 'ended',
+                startDate: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000),
+                endDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000),
+            });
+            await seedContestEntry(app, contestId, user1Id, { voteCount: 10, rank: 1 });
+            await seedContestEntry(app, contestId, user2Id, { voteCount: 7, rank: 2 });
+        });
+
+        it('GET /weekly-top → weekKey 형식 YYYY-WXX', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            expect(res.body.data.weekKey).toMatch(/^\d{4}-W\d{2}$/);
+        });
+
+        it('GET /weekly-top → topEntries 최대 3개, voteCount 내림차순', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            const { topEntries } = res.body.data;
+            expect(topEntries.length).toBeGreaterThan(0);
+            expect(topEntries.length).toBeLessThanOrEqual(3);
+            if (topEntries.length >= 2) {
+                expect(topEntries[0].voteCount).toBeGreaterThanOrEqual(topEntries[1].voteCount);
+            }
+        });
+
+        it('GET /weekly-top → topEntries 항목 필드 존재', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            const entry = res.body.data.topEntries[0];
+            expect(entry).toHaveProperty('id');
+            expect(entry).toHaveProperty('photoUrl');
+            expect(entry).toHaveProperty('rank');
+            expect(typeof entry.voteCount).toBe('number');
+        });
+
+        it('GET /weekly-top → calculatedAt ISO 문자열', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/contest/weekly-top')
+                .expect(200);
+
+            expect(new Date(res.body.data.calculatedAt).toString()).not.toBe('Invalid Date');
         });
     });
 });


### PR DESCRIPTION
## Summary
- § 3.13 명예의 전당 잔여 이슈 #147 구현
- `GET /v2/contest/weekly-top` — 홈 화면 명예의 전당 영역 연동용 API 추가
- E2E 테스트 37개 전부 통과 (기존 31개 → 7개 신규 추가)

## 주요 구현 내용

**[contest] 지난주 TOP 3 조회 API**
- `GET /v2/contest/weekly-top` 신규 엔드포인트 (#147)
- `GetWeeklyTopUseCase`: 가장 최근 종료된 콘테스트의 voteCount 내림차순 TOP 3 반환
- `endDate` 기반 ISO 8601 weekKey 계산 (예: `"2026-W21"`)
- 종료 콘테스트이므로 voteCount 항상 공개 (투표 전/후 조건부 정책 미적용)
- 종료 콘테스트 없으면 `data: null` 반환

**[e2e] contest 테스트 7개 신규 추가**
- 콘테스트 없음 → `data: null`
- 종료 콘테스트, 항목 없음 → `topEntries: []`, `weekKey` 형식 검증
- 종료 콘테스트, 항목 있음 → TOP 3 반환, voteCount 내림차순, 항목 필드 존재, `calculatedAt` 검증

## 변경 이유
- `GET /v2/contest/previous-ranking`이 유사한 데이터를 제공하지만 URL과 응답 구조가 다름
- 홈 화면에서 `weekKey` / `calculatedAt` 포함 경량 응답이 필요했고, 프론트엔드와 계약된 별도 엔드포인트 필요

## 영향 범위
- Breaking Change 없음 — 기존 API 응답/계약 무변경
- 신규 엔드포인트 추가만이며 기존 contest 로직 수정 없음

## Test Plan
- [x] `GET /v2/contest/weekly-top` E2E 7개 전부 통과
- [x] 전체 contest E2E 실행: 37/37 통과
- [x] `pnpm typecheck` 에러 없음