### PR TITLE
feat(community): 게시글 isLiked 필드 추가 및 좋아요 알림 연동 (#136)

### DIFF
--- a/src/api/community/application/types/community-post-result.type.ts
+++ b/src/api/community/application/types/community-post-result.type.ts
@@ -37,6 +37,8 @@ export interface CommunityPostCardResult {
     commentCount: number;
     saveCount: number;
     createdAt: string;
+    /** 현재 요청 사용자의 좋아요 여부. 비인증 요청 시 false. */
+    isLiked: boolean;
 }
 
 export interface CommunityPostDetailResult {
@@ -54,4 +56,6 @@ export interface CommunityPostDetailResult {
     viewCount: number;
     createdAt: string;
     commentPreview: CommunityPostCommentResult[];
+    /** 현재 요청 사용자의 좋아요 여부. 비인증 요청 시 false. */
+    isLiked: boolean;
 }

--- a/src/api/community/application/use-cases/get-community-post-detail.use-case.ts
+++ b/src/api/community/application/use-cases/get-community-post-detail.use-case.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 import { CommunityPostMapperService } from '../../domain/services/community-post-mapper.service';
+import { COMMUNITY_LIKE_PORT, type CommunityLikePort } from '../ports/community-like.port';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import type { CommunityPostDetailResult } from '../types/community-post-result.type';
 
@@ -15,22 +16,23 @@ export class GetCommunityPostDetailUseCase {
     constructor(
         @Inject(COMMUNITY_POST_READER_PORT)
         private readonly reader: CommunityPostReaderPort,
+        @Inject(COMMUNITY_LIKE_PORT)
+        private readonly likePort: CommunityLikePort,
         private readonly mapper: CommunityPostMapperService,
     ) {}
 
-    async execute(postId: string): Promise<CommunityPostDetailResult> {
+    async execute(postId: string, userId?: string): Promise<CommunityPostDetailResult> {
         const snapshot = await this.reader.readPostById(postId);
         if (!snapshot) {
             throw new BadRequestException('해당 게시글을 찾을 수 없습니다.');
         }
 
-        const { snapshots: commentSnapshots } = await this.reader.listComments({
-            postId,
-            skip: 0,
-            limit: COMMENT_PREVIEW_LIMIT,
-        });
+        const [{ snapshots: commentSnapshots }, isLiked] = await Promise.all([
+            this.reader.listComments({ postId, skip: 0, limit: COMMENT_PREVIEW_LIMIT }),
+            userId ? this.likePort.isLiked(userId, postId) : Promise.resolve(false),
+        ]);
         const commentPreview = commentSnapshots.map((c) => this.mapper.toComment(c));
 
-        return this.mapper.toDetail(snapshot, commentPreview);
+        return this.mapper.toDetail(snapshot, commentPreview, isLiked);
     }
 }

--- a/src/api/community/application/use-cases/get-community-post-list.use-case.ts
+++ b/src/api/community/application/use-cases/get-community-post-list.use-case.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 import { buildPageResult, type PageResult } from '../../../../common/types/page-result.type';
 import { CommunityPostMapperService } from '../../domain/services/community-post-mapper.service';
+import { COMMUNITY_LIKE_PORT, type CommunityLikePort } from '../ports/community-like.port';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import type { CommunityPostCardResult } from '../types/community-post-result.type';
 import type { CommunityPetType, CommunityPostSort } from '../types/community-post.type';
@@ -14,6 +15,8 @@ export class GetCommunityPostListUseCase {
     constructor(
         @Inject(COMMUNITY_POST_READER_PORT)
         private readonly reader: CommunityPostReaderPort,
+        @Inject(COMMUNITY_LIKE_PORT)
+        private readonly likePort: CommunityLikePort,
         private readonly mapper: CommunityPostMapperService,
     ) {}
 
@@ -24,6 +27,8 @@ export class GetCommunityPostListUseCase {
         sort?: CommunityPostSort;
         page?: number;
         pageSize?: number;
+        /** 현재 요청 사용자 ID. 없으면 isLiked 는 모두 false. */
+        userId?: string;
     }): Promise<PageResult<CommunityPostCardResult>> {
         const page = Math.max(1, input.page ?? 1);
         const pageSize = Math.min(PAGE_SIZE_MAX, Math.max(1, input.pageSize ?? PAGE_SIZE_DEFAULT));
@@ -38,7 +43,14 @@ export class GetCommunityPostListUseCase {
             limit: pageSize,
         });
 
-        const items = snapshots.map((s) => this.mapper.toCard(s));
+        const likedSet = input.userId
+            ? await this.likePort.findLikedPostIds(
+                  input.userId,
+                  snapshots.map((s) => s.postId),
+              )
+            : new Set<string>();
+
+        const items = snapshots.map((s) => this.mapper.toCard(s, likedSet.has(s.postId)));
         return buildPageResult(items, page, pageSize, totalItems);
     }
 }

--- a/src/api/community/application/use-cases/like-community-post.use-case.ts
+++ b/src/api/community/application/use-cases/like-community-post.use-case.ts
@@ -1,16 +1,26 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
 
+import { NotificationType, RecipientType } from '../../../../common/enum/user.enum';
+import { NOTIFICATION_DISPATCH_PORT } from '../../../notification/application/ports/notification-dispatch.port';
+import type { NotificationDispatchPort } from '../../../notification/application/ports/notification-dispatch.port';
+import { COMMUNITY_AUTHOR_READER_PORT, type CommunityAuthorReaderPort } from '../ports/community-author-reader.port';
 import { COMMUNITY_LIKE_PORT, type CommunityLikePort } from '../ports/community-like.port';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import type { CommunityAuthorModel } from '../types/community-post.type';
 
 @Injectable()
 export class LikeCommunityPostUseCase {
+    private readonly logger = new Logger(LikeCommunityPostUseCase.name);
+
     constructor(
         @Inject(COMMUNITY_POST_READER_PORT)
         private readonly reader: CommunityPostReaderPort,
         @Inject(COMMUNITY_LIKE_PORT)
         private readonly likePort: CommunityLikePort,
+        @Inject(COMMUNITY_AUTHOR_READER_PORT)
+        private readonly authorReader: CommunityAuthorReaderPort,
+        @Inject(NOTIFICATION_DISPATCH_PORT)
+        private readonly notificationDispatch: NotificationDispatchPort,
     ) {}
 
     async execute(
@@ -22,6 +32,38 @@ export class LikeCommunityPostUseCase {
         if (!exists) throw new BadRequestException('해당 게시글을 찾을 수 없습니다.');
 
         const { alreadyLiked } = await this.likePort.like(postId, userId, userModel);
+
+        if (!alreadyLiked) {
+            this.sendLikeNotification(postId, userId, userModel).catch((err: Error) => {
+                this.logger.error(`[execute] 좋아요 알림 발송 실패: ${err.message}`, { postId, userId });
+            });
+        }
+
         return { postId, liked: !alreadyLiked };
+    }
+
+    private async sendLikeNotification(
+        postId: string,
+        likerId: string,
+        likerModel: CommunityAuthorModel,
+    ): Promise<void> {
+        const post = await this.reader.readPostById(postId);
+        if (!post || post.authorId === likerId) return;
+
+        const likerRole = likerModel === 'Breeder' ? 'breeder' : 'adopter';
+        const likerSnapshot = await this.authorReader.readAuthorSnapshot(likerId, likerRole);
+        const likerNickname = likerSnapshot?.authorNickname ?? '누군가';
+
+        const authorRole = post.authorModel === 'Breeder' ? 'breeder' : 'adopter';
+        const recipientType = authorRole === 'breeder' ? RecipientType.BREEDER : RecipientType.ADOPTER;
+
+        await this.notificationDispatch
+            .to(post.authorId, recipientType)
+            .type(NotificationType.COMMUNITY_POST_LIKED)
+            .title('좋아요를 받았어요!')
+            .content(`${likerNickname}님이 내 게시글을 좋아합니다.`)
+            .metadata({ likerNickname, postId })
+            .targetUrl(`/community/posts/${postId}`)
+            .send();
     }
 }

--- a/src/api/community/community.module-definition.ts
+++ b/src/api/community/community.module-definition.ts
@@ -1,6 +1,7 @@
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { StorageModule } from '../../common/storage/storage.module';
+import { NotificationModule } from '../notification/notification.module';
 import { Adopter, AdopterSchema } from '../../schema/adopter.schema';
 import { Breeder, BreederSchema } from '../../schema/breeder.schema';
 import { CommunityBookmark, CommunityBookmarkSchema } from '../../schema/community-bookmark.schema';
@@ -73,7 +74,7 @@ const SCHEMA_IMPORTS = MongooseModule.forFeature([
     { name: Breeder.name, schema: BreederSchema },
 ]);
 
-export const COMMUNITY_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule];
+export const COMMUNITY_MODULE_IMPORTS = [SCHEMA_IMPORTS, StorageModule, NotificationModule];
 
 export const COMMUNITY_MODULE_CONTROLLERS = [
     CommunityPostListController,

--- a/src/api/community/controller/community-post-detail.controller.ts
+++ b/src/api/community/controller/community-post-detail.controller.ts
@@ -1,5 +1,6 @@
 import { Get, Param } from '@nestjs/common';
 
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
 import { GetCommunityPostDetailUseCase } from '../application/use-cases/get-community-post-detail.use-case';
 import { COMMUNITY_RESPONSE_MESSAGES } from '../constants/community-response-messages';
@@ -16,8 +17,11 @@ export class CommunityPostDetailController {
 
     @Get('posts/:postId')
     @ApiGetCommunityPostDetailEndpoint()
-    async detail(@Param('postId') postId: string): Promise<ApiResponseDto<CommunityPostDetailResponseDto>> {
-        const result = await this.getDetailUseCase.execute(postId);
+    async detail(
+        @Param('postId') postId: string,
+        @CurrentUser('userId') userId?: string,
+    ): Promise<ApiResponseDto<CommunityPostDetailResponseDto>> {
+        const result = await this.getDetailUseCase.execute(postId, userId);
         return ApiResponseDto.success(result, COMMUNITY_RESPONSE_MESSAGES.detailRetrieved);
     }
 }

--- a/src/api/community/controller/community-post-list.controller.ts
+++ b/src/api/community/controller/community-post-list.controller.ts
@@ -30,6 +30,7 @@ export class CommunityPostListController {
             sort: query.sort,
             page: query.page,
             pageSize: query.pageSize,
+            userId,
         });
         return ApiResponseDto.success(
             PaginationResponseDto.fromPageResult(result),

--- a/src/api/community/domain/services/community-post-mapper.service.ts
+++ b/src/api/community/domain/services/community-post-mapper.service.ts
@@ -20,7 +20,7 @@ export class CommunityPostMapperService {
         private readonly assetUrl: CommunityAssetUrlPort,
     ) {}
 
-    toCard(snapshot: CommunityPostSnapshot): CommunityPostCardResult {
+    toCard(snapshot: CommunityPostSnapshot, isLiked = false): CommunityPostCardResult {
         const photoUrls = snapshot.photos
             .map((fileName) => this.assetUrl.toSignedUrl(fileName))
             .filter((url): url is string => !!url);
@@ -42,12 +42,14 @@ export class CommunityPostMapperService {
             commentCount: snapshot.commentCount,
             saveCount: snapshot.saveCount,
             createdAt: snapshot.createdAt.toISOString(),
+            isLiked,
         };
     }
 
     toDetail(
         snapshot: CommunityPostSnapshot,
         comments: CommunityPostCommentResult[],
+        isLiked = false,
     ): CommunityPostDetailResult {
         const photoUrls = snapshot.photos
             .map((fileName) => this.assetUrl.toSignedUrl(fileName))
@@ -71,6 +73,7 @@ export class CommunityPostMapperService {
             viewCount: snapshot.viewCount,
             createdAt: snapshot.createdAt.toISOString(),
             commentPreview: comments,
+            isLiked,
         };
     }
 

--- a/src/api/community/dto/response/community-post-card.dto.ts
+++ b/src/api/community/dto/response/community-post-card.dto.ts
@@ -53,4 +53,7 @@ export class CommunityPostCardResponseDto {
 
     @ApiProperty({ description: '작성 시각 (ISO 8601)', example: '2026-04-01T10:00:00.000Z' })
     createdAt: string;
+
+    @ApiProperty({ description: '현재 요청 사용자의 좋아요 여부 (비인증 시 false)', example: false })
+    isLiked: boolean;
 }

--- a/src/api/community/dto/response/community-post-detail.dto.ts
+++ b/src/api/community/dto/response/community-post-detail.dto.ts
@@ -53,4 +53,7 @@ export class CommunityPostDetailResponseDto {
         type: [CommunityPostCommentResponseDto],
     })
     commentPreview: CommunityPostCommentResponseDto[];
+
+    @ApiProperty({ description: '현재 요청 사용자의 좋아요 여부 (비인증 시 false)', example: false })
+    isLiked: boolean;
 }

--- a/src/api/community/test/application/use-cases/get-community-post-detail.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/get-community-post-detail.use-case.spec.ts
@@ -22,7 +22,8 @@ const postSnap = {
 
 describe('GetCommunityPostDetailUseCase', () => {
     const reader = { listPosts: jest.fn(), readPostById: jest.fn(), listComments: jest.fn() };
-    const useCase = new GetCommunityPostDetailUseCase(reader as any, mapper);
+    const likePort = { like: jest.fn(), unlike: jest.fn(), isLiked: jest.fn().mockResolvedValue(false), findLikedPostIds: jest.fn() };
+    const useCase = new GetCommunityPostDetailUseCase(reader as any, likePort as any, mapper);
 
     beforeEach(() => jest.clearAllMocks());
 

--- a/src/api/community/test/application/use-cases/get-community-post-list.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/get-community-post-list.use-case.spec.ts
@@ -6,7 +6,8 @@ const mapper = new CommunityPostMapperService(assetUrl as any);
 
 describe('GetCommunityPostListUseCase', () => {
     const reader = { listPosts: jest.fn(), readPostById: jest.fn(), listComments: jest.fn() };
-    const useCase = new GetCommunityPostListUseCase(reader as any, mapper);
+    const likePort = { like: jest.fn(), unlike: jest.fn(), isLiked: jest.fn(), findLikedPostIds: jest.fn().mockResolvedValue(new Set()) };
+    const useCase = new GetCommunityPostListUseCase(reader as any, likePort as any, mapper);
 
     beforeEach(() => jest.clearAllMocks());
 

--- a/src/api/community/test/application/use-cases/like-community-post.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/like-community-post.use-case.spec.ts
@@ -18,10 +18,28 @@ const likePort = {
     findLikedPostIds: jest.fn(),
 };
 
+const authorReader = { readAuthorSnapshot: jest.fn().mockResolvedValue(null) };
+const notificationDispatch = {
+    to: jest.fn().mockReturnValue({
+        type: jest.fn().mockReturnThis(),
+        title: jest.fn().mockReturnThis(),
+        content: jest.fn().mockReturnThis(),
+        metadata: jest.fn().mockReturnThis(),
+        targetUrl: jest.fn().mockReturnThis(),
+        send: jest.fn().mockResolvedValue({}),
+    }),
+    createNotification: jest.fn(),
+};
+
 beforeEach(() => jest.clearAllMocks());
 
 describe('LikeCommunityPostUseCase', () => {
-    const useCase = new LikeCommunityPostUseCase(reader as any, likePort as any);
+    const useCase = new LikeCommunityPostUseCase(
+        reader as any,
+        likePort as any,
+        authorReader as any,
+        notificationDispatch as any,
+    );
 
     it('존재하지 않는 게시글 → BadRequestException, like 미호출', async () => {
         reader.existsActivePost.mockResolvedValueOnce(false);

--- a/src/api/notification/constants/notification-message.constant.ts
+++ b/src/api/notification/constants/notification-message.constant.ts
@@ -68,4 +68,8 @@ export const NOTIFICATION_MESSAGES: Record<NotificationType, { title: string; bo
         title: '{title}',
         body: '{body}',
     },
+    [NotificationType.COMMUNITY_POST_LIKED]: {
+        title: '좋아요를 받았어요!',
+        body: '{likerNickname}님이 내 게시글을 좋아합니다.',
+    },
 };

--- a/src/common/enum/user.enum.ts
+++ b/src/common/enum/user.enum.ts
@@ -169,6 +169,9 @@ export enum NotificationType {
 
     // 반려동물 등록
     NEW_PET_REGISTERED = 'new_pet_registered', // 새 반려동물 등록
+
+    // 커뮤니티
+    COMMUNITY_POST_LIKED = 'community_post_liked', // 커뮤니티 게시글 좋아요
 }
 
 export enum RecipientType {


### PR DESCRIPTION
## Summary
- § 3.12 커뮤니티 이슈 #136 잔여 항목 구현 (isLiked 응답 필드 + 좋아요 알림 연동)
- 기존 좋아요/취소 API는 있었으나 게시글 응답에 isLiked 누락 및 알림 미연동 상태였음
- 커뮤니티 단위 테스트 13개 전부 통과

## 주요 구현 내용
**[#136] isLiked 필드 추가**
- CommunityPostCardResponseDto, CommunityPostDetailResponseDto에 isLiked: boolean 필드 추가
- GetCommunityPostListUseCase: findLikedPostIds 배치 조회로 목록 전체 isLiked 계산 (N+1 방지)
- GetCommunityPostDetailUseCase: isLiked 단건 조회 + listComments와 Promise.all 병렬 처리
- 비인증 요청은 isLiked: false 기본값 반환

**[#136] 좋아요 알림 연동**
- NotificationType.COMMUNITY_POST_LIKED 추가
- LikeCommunityPostUseCase: 신규 좋아요 시 게시글 작성자에게 알림 발송
    - 자기 게시글 좋아요는 알림 제외
    - 알림 발송 실패가 좋아요 응답에 영향 없도록 비동기 .catch() 처리
- CommunityModule에 NotificationModule 의존성 추가

## 영향 범위
- Breaking Change 없음 — 기존 좋아요 API 응답 계약 무변경
- 목록/상세 응답에 isLiked 필드 추가 (신규 필드, 하위 호환)

## Test Plan
- [x] 커뮤니티 단위 테스트 13개 전부 통과
- [x] pnpm typecheck 에러 없음
- [x] 커뮤니티 E2E 6 suites / 70 tests 전부 통과
