### PR TITLE
fix(community): isSaved 필드 누락 및 조회 수 중복 방지 구현 (#135, #137)

### DIFF
--- a/src/api/community/application/types/community-post-result.type.ts
+++ b/src/api/community/application/types/community-post-result.type.ts
@@ -39,6 +39,8 @@ export interface CommunityPostCardResult {
     createdAt: string;
     /** 현재 요청 사용자의 좋아요 여부. 비인증 요청 시 false. */
     isLiked: boolean;
+    /** 현재 요청 사용자의 저장 여부. 비인증 요청 시 false. */
+    isSaved: boolean;
 }
 
 export interface CommunityPostDetailResult {
@@ -58,4 +60,6 @@ export interface CommunityPostDetailResult {
     commentPreview: CommunityPostCommentResult[];
     /** 현재 요청 사용자의 좋아요 여부. 비인증 요청 시 false. */
     isLiked: boolean;
+    /** 현재 요청 사용자의 저장 여부. 비인증 요청 시 false. */
+    isSaved: boolean;
 }

--- a/src/api/community/application/use-cases/get-community-post-detail.use-case.ts
+++ b/src/api/community/application/use-cases/get-community-post-detail.use-case.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 import { CommunityPostMapperService } from '../../domain/services/community-post-mapper.service';
+import { COMMUNITY_BOOKMARK_PORT, type CommunityBookmarkPort } from '../ports/community-bookmark.port';
 import { COMMUNITY_LIKE_PORT, type CommunityLikePort } from '../ports/community-like.port';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import type { CommunityPostDetailResult } from '../types/community-post-result.type';
@@ -18,6 +19,8 @@ export class GetCommunityPostDetailUseCase {
         private readonly reader: CommunityPostReaderPort,
         @Inject(COMMUNITY_LIKE_PORT)
         private readonly likePort: CommunityLikePort,
+        @Inject(COMMUNITY_BOOKMARK_PORT)
+        private readonly bookmarkPort: CommunityBookmarkPort,
         private readonly mapper: CommunityPostMapperService,
     ) {}
 
@@ -27,12 +30,13 @@ export class GetCommunityPostDetailUseCase {
             throw new BadRequestException('해당 게시글을 찾을 수 없습니다.');
         }
 
-        const [{ snapshots: commentSnapshots }, isLiked] = await Promise.all([
+        const [{ snapshots: commentSnapshots }, isLiked, savedSet] = await Promise.all([
             this.reader.listComments({ postId, skip: 0, limit: COMMENT_PREVIEW_LIMIT }),
             userId ? this.likePort.isLiked(userId, postId) : Promise.resolve(false),
+            userId ? this.bookmarkPort.findSavedPostIds(userId, [postId]) : Promise.resolve(new Set<string>()),
         ]);
         const commentPreview = commentSnapshots.map((c) => this.mapper.toComment(c));
 
-        return this.mapper.toDetail(snapshot, commentPreview, isLiked);
+        return this.mapper.toDetail(snapshot, commentPreview, isLiked, savedSet.has(postId));
     }
 }

--- a/src/api/community/application/use-cases/get-community-post-list.use-case.ts
+++ b/src/api/community/application/use-cases/get-community-post-list.use-case.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 import { buildPageResult, type PageResult } from '../../../../common/types/page-result.type';
 import { CommunityPostMapperService } from '../../domain/services/community-post-mapper.service';
+import { COMMUNITY_BOOKMARK_PORT, type CommunityBookmarkPort } from '../ports/community-bookmark.port';
 import { COMMUNITY_LIKE_PORT, type CommunityLikePort } from '../ports/community-like.port';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import type { CommunityPostCardResult } from '../types/community-post-result.type';
@@ -17,6 +18,8 @@ export class GetCommunityPostListUseCase {
         private readonly reader: CommunityPostReaderPort,
         @Inject(COMMUNITY_LIKE_PORT)
         private readonly likePort: CommunityLikePort,
+        @Inject(COMMUNITY_BOOKMARK_PORT)
+        private readonly bookmarkPort: CommunityBookmarkPort,
         private readonly mapper: CommunityPostMapperService,
     ) {}
 
@@ -27,7 +30,7 @@ export class GetCommunityPostListUseCase {
         sort?: CommunityPostSort;
         page?: number;
         pageSize?: number;
-        /** 현재 요청 사용자 ID. 없으면 isLiked 는 모두 false. */
+        /** 현재 요청 사용자 ID. 없으면 isLiked/isSaved 는 모두 false. */
         userId?: string;
     }): Promise<PageResult<CommunityPostCardResult>> {
         const page = Math.max(1, input.page ?? 1);
@@ -43,14 +46,18 @@ export class GetCommunityPostListUseCase {
             limit: pageSize,
         });
 
-        const likedSet = input.userId
-            ? await this.likePort.findLikedPostIds(
-                  input.userId,
-                  snapshots.map((s) => s.postId),
-              )
-            : new Set<string>();
+        const postIds = snapshots.map((s) => s.postId);
 
-        const items = snapshots.map((s) => this.mapper.toCard(s, likedSet.has(s.postId)));
+        const [likedSet, savedSet] = input.userId
+            ? await Promise.all([
+                  this.likePort.findLikedPostIds(input.userId, postIds),
+                  this.bookmarkPort.findSavedPostIds(input.userId, postIds),
+              ])
+            : [new Set<string>(), new Set<string>()];
+
+        const items = snapshots.map((s) =>
+            this.mapper.toCard(s, likedSet.has(s.postId), savedSet.has(s.postId)),
+        );
         return buildPageResult(items, page, pageSize, totalItems);
     }
 }

--- a/src/api/community/application/use-cases/increment-view-count.use-case.ts
+++ b/src/api/community/application/use-cases/increment-view-count.use-case.ts
@@ -1,7 +1,12 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
+import { REDIS_SERVICE_TOKEN } from '../../../../common/redis/redis.token';
+import type { RedisService } from '../../../../common/redis/redis.module';
 import { COMMUNITY_POST_READER_PORT, type CommunityPostReaderPort } from '../ports/community-post-reader.port';
 import { COMMUNITY_POST_WRITER_PORT, type CommunityPostWriterPort } from '../ports/community-post-writer.port';
+
+/** 같은 사용자가 24시간 내 재조회 시 viewCount 증가를 생략하는 TTL (초) */
+const VIEW_DEDUP_TTL_SECONDS = 86400;
 
 @Injectable()
 export class IncrementViewCountUseCase {
@@ -10,13 +15,28 @@ export class IncrementViewCountUseCase {
         private readonly reader: CommunityPostReaderPort,
         @Inject(COMMUNITY_POST_WRITER_PORT)
         private readonly writer: CommunityPostWriterPort,
+        @Inject(REDIS_SERVICE_TOKEN)
+        private readonly redis: RedisService,
     ) {}
 
-    async execute(postId: string): Promise<void> {
+    async execute(postId: string, userId?: string): Promise<void> {
         const exists = await this.reader.existsActivePost(postId);
         if (!exists) {
             throw new BadRequestException('해당 게시글을 찾을 수 없습니다.');
         }
+
+        // 인증된 사용자는 24시간 내 중복 조회를 생략 (Redis TTL dedup)
+        if (userId) {
+            const key = `community:view:${userId}:${postId}`;
+            const alreadyViewed = await this.redis.exists(key);
+            if (alreadyViewed) return;
+
+            await this.writer.incrementViewCount(postId);
+            await this.redis.set(key, '1', VIEW_DEDUP_TTL_SECONDS);
+            return;
+        }
+
+        // 비인증 사용자는 항상 증가
         await this.writer.incrementViewCount(postId);
     }
 }

--- a/src/api/community/controller/community-post-view-count.controller.ts
+++ b/src/api/community/controller/community-post-view-count.controller.ts
@@ -1,6 +1,7 @@
 import { Param, Post } from '@nestjs/common';
 
 import { ApiResponseDto } from '../../../common/dto/response/api-response.dto';
+import { CurrentUser } from '../../../common/decorator/current-user.decorator';
 import { IncrementViewCountUseCase } from '../application/use-cases/increment-view-count.use-case';
 import { COMMUNITY_RESPONSE_MESSAGES } from '../constants/community-response-messages';
 import { CommunityPublicController } from '../decorator/community-public-controller.decorator';
@@ -15,8 +16,11 @@ export class CommunityPostViewCountController {
 
     @Post('posts/:postId/view')
     @ApiIncrementViewCountEndpoint()
-    async view(@Param('postId') postId: string): Promise<ApiResponseDto<null>> {
-        await this.incrementViewCountUseCase.execute(postId);
+    async view(
+        @Param('postId') postId: string,
+        @CurrentUser('userId') userId?: string,
+    ): Promise<ApiResponseDto<null>> {
+        await this.incrementViewCountUseCase.execute(postId, userId);
         return ApiResponseDto.success(null, COMMUNITY_RESPONSE_MESSAGES.viewCounted);
     }
 }

--- a/src/api/community/domain/services/community-post-mapper.service.ts
+++ b/src/api/community/domain/services/community-post-mapper.service.ts
@@ -20,7 +20,7 @@ export class CommunityPostMapperService {
         private readonly assetUrl: CommunityAssetUrlPort,
     ) {}
 
-    toCard(snapshot: CommunityPostSnapshot, isLiked = false): CommunityPostCardResult {
+    toCard(snapshot: CommunityPostSnapshot, isLiked = false, isSaved = false): CommunityPostCardResult {
         const photoUrls = snapshot.photos
             .map((fileName) => this.assetUrl.toSignedUrl(fileName))
             .filter((url): url is string => !!url);
@@ -43,6 +43,7 @@ export class CommunityPostMapperService {
             saveCount: snapshot.saveCount,
             createdAt: snapshot.createdAt.toISOString(),
             isLiked,
+            isSaved,
         };
     }
 
@@ -50,6 +51,7 @@ export class CommunityPostMapperService {
         snapshot: CommunityPostSnapshot,
         comments: CommunityPostCommentResult[],
         isLiked = false,
+        isSaved = false,
     ): CommunityPostDetailResult {
         const photoUrls = snapshot.photos
             .map((fileName) => this.assetUrl.toSignedUrl(fileName))
@@ -74,6 +76,7 @@ export class CommunityPostMapperService {
             createdAt: snapshot.createdAt.toISOString(),
             commentPreview: comments,
             isLiked,
+            isSaved,
         };
     }
 

--- a/src/api/community/dto/response/community-post-card.dto.ts
+++ b/src/api/community/dto/response/community-post-card.dto.ts
@@ -56,4 +56,7 @@ export class CommunityPostCardResponseDto {
 
     @ApiProperty({ description: '현재 요청 사용자의 좋아요 여부 (비인증 시 false)', example: false })
     isLiked: boolean;
+
+    @ApiProperty({ description: '현재 요청 사용자의 저장 여부 (비인증 시 false)', example: false })
+    isSaved: boolean;
 }

--- a/src/api/community/dto/response/community-post-detail.dto.ts
+++ b/src/api/community/dto/response/community-post-detail.dto.ts
@@ -56,4 +56,7 @@ export class CommunityPostDetailResponseDto {
 
     @ApiProperty({ description: '현재 요청 사용자의 좋아요 여부 (비인증 시 false)', example: false })
     isLiked: boolean;
+
+    @ApiProperty({ description: '현재 요청 사용자의 저장 여부 (비인증 시 false)', example: false })
+    isSaved: boolean;
 }

--- a/src/api/community/test/application/use-cases/get-community-post-detail.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/get-community-post-detail.use-case.spec.ts
@@ -22,8 +22,19 @@ const postSnap = {
 
 describe('GetCommunityPostDetailUseCase', () => {
     const reader = { listPosts: jest.fn(), readPostById: jest.fn(), listComments: jest.fn() };
-    const likePort = { like: jest.fn(), unlike: jest.fn(), isLiked: jest.fn().mockResolvedValue(false), findLikedPostIds: jest.fn() };
-    const useCase = new GetCommunityPostDetailUseCase(reader as any, likePort as any, mapper);
+    const likePort = {
+        like: jest.fn(),
+        unlike: jest.fn(),
+        isLiked: jest.fn().mockResolvedValue(false),
+        findLikedPostIds: jest.fn(),
+    };
+    const bookmarkPort = {
+        save: jest.fn(),
+        unsave: jest.fn(),
+        listSavedPostIds: jest.fn(),
+        findSavedPostIds: jest.fn().mockResolvedValue(new Set()),
+    };
+    const useCase = new GetCommunityPostDetailUseCase(reader as any, likePort as any, bookmarkPort as any, mapper);
 
     beforeEach(() => jest.clearAllMocks());
 
@@ -42,5 +53,38 @@ describe('GetCommunityPostDetailUseCase', () => {
         expect(reader.listComments).toHaveBeenCalledWith({ postId: 'p-1', skip: 0, limit: 5 });
         expect(result.postId).toBe('p-1');
         expect(result.commentPreview).toEqual([]);
+    });
+
+    it('비인증(userId 없음) → isSaved: false, findSavedPostIds 미호출', async () => {
+        reader.readPostById.mockResolvedValueOnce(postSnap);
+        reader.listComments.mockResolvedValueOnce({ snapshots: [], totalItems: 0 });
+
+        const result = await useCase.execute('p-1');
+
+        expect(bookmarkPort.findSavedPostIds).not.toHaveBeenCalled();
+        expect(result.isSaved).toBe(false);
+    });
+
+    it('인증 + 저장된 게시글 → isSaved: true', async () => {
+        reader.readPostById.mockResolvedValueOnce(postSnap);
+        reader.listComments.mockResolvedValueOnce({ snapshots: [], totalItems: 0 });
+        likePort.isLiked.mockResolvedValueOnce(false);
+        bookmarkPort.findSavedPostIds.mockResolvedValueOnce(new Set(['p-1']));
+
+        const result = await useCase.execute('p-1', 'u-1');
+
+        expect(bookmarkPort.findSavedPostIds).toHaveBeenCalledWith('u-1', ['p-1']);
+        expect(result.isSaved).toBe(true);
+    });
+
+    it('인증 + 저장 안 한 게시글 → isSaved: false', async () => {
+        reader.readPostById.mockResolvedValueOnce(postSnap);
+        reader.listComments.mockResolvedValueOnce({ snapshots: [], totalItems: 0 });
+        likePort.isLiked.mockResolvedValueOnce(false);
+        bookmarkPort.findSavedPostIds.mockResolvedValueOnce(new Set());
+
+        const result = await useCase.execute('p-1', 'u-1');
+
+        expect(result.isSaved).toBe(false);
     });
 });

--- a/src/api/community/test/application/use-cases/get-community-post-list.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/get-community-post-list.use-case.spec.ts
@@ -4,10 +4,35 @@ import { CommunityPostMapperService } from '../../../domain/services/community-p
 const assetUrl = { toSignedUrl: () => undefined };
 const mapper = new CommunityPostMapperService(assetUrl as any);
 
+const makeSnap = (postId: string) => ({
+    postId,
+    authorId: 'a-1',
+    authorModel: 'Adopter' as const,
+    authorNickname: '닉',
+    body: '본문',
+    photos: [],
+    likeCount: 0,
+    commentCount: 0,
+    saveCount: 0,
+    viewCount: 0,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+});
+
 describe('GetCommunityPostListUseCase', () => {
     const reader = { listPosts: jest.fn(), readPostById: jest.fn(), listComments: jest.fn() };
-    const likePort = { like: jest.fn(), unlike: jest.fn(), isLiked: jest.fn(), findLikedPostIds: jest.fn().mockResolvedValue(new Set()) };
-    const useCase = new GetCommunityPostListUseCase(reader as any, likePort as any, mapper);
+    const likePort = {
+        like: jest.fn(),
+        unlike: jest.fn(),
+        isLiked: jest.fn(),
+        findLikedPostIds: jest.fn().mockResolvedValue(new Set()),
+    };
+    const bookmarkPort = {
+        save: jest.fn(),
+        unsave: jest.fn(),
+        listSavedPostIds: jest.fn(),
+        findSavedPostIds: jest.fn().mockResolvedValue(new Set()),
+    };
+    const useCase = new GetCommunityPostListUseCase(reader as any, likePort as any, bookmarkPort as any, mapper);
 
     beforeEach(() => jest.clearAllMocks());
 
@@ -17,6 +42,7 @@ describe('GetCommunityPostListUseCase', () => {
         expect(reader.listPosts).toHaveBeenCalledWith({
             petType: undefined,
             category: undefined,
+            authorId: undefined,
             sort: 'latest',
             skip: 0,
             limit: 15,
@@ -50,5 +76,27 @@ describe('GetCommunityPostListUseCase', () => {
             category: '레오파드',
             sort: 'popular',
         });
+    });
+
+    it('비인증(userId 없음) → isSaved 모두 false, findSavedPostIds 미호출', async () => {
+        reader.listPosts.mockResolvedValueOnce({ snapshots: [makeSnap('p-1')], totalItems: 1 });
+        likePort.findLikedPostIds.mockResolvedValueOnce(new Set());
+
+        const result = await useCase.execute({});
+
+        expect(bookmarkPort.findSavedPostIds).not.toHaveBeenCalled();
+        expect(result.items[0].isSaved).toBe(false);
+    });
+
+    it('인증(userId 있음) + 저장된 게시글 → isSaved: true', async () => {
+        reader.listPosts.mockResolvedValueOnce({ snapshots: [makeSnap('p-saved'), makeSnap('p-other')], totalItems: 2 });
+        likePort.findLikedPostIds.mockResolvedValueOnce(new Set());
+        bookmarkPort.findSavedPostIds.mockResolvedValueOnce(new Set(['p-saved']));
+
+        const result = await useCase.execute({ userId: 'u-1' });
+
+        expect(bookmarkPort.findSavedPostIds).toHaveBeenCalledWith('u-1', ['p-saved', 'p-other']);
+        expect(result.items.find((i) => i.postId === 'p-saved')?.isSaved).toBe(true);
+        expect(result.items.find((i) => i.postId === 'p-other')?.isSaved).toBe(false);
     });
 });

--- a/src/api/community/test/application/use-cases/increment-view-count.use-case.spec.ts
+++ b/src/api/community/test/application/use-cases/increment-view-count.use-case.spec.ts
@@ -2,46 +2,78 @@ import { BadRequestException } from '@nestjs/common';
 
 import { IncrementViewCountUseCase } from '../../../application/use-cases/increment-view-count.use-case';
 
+const reader = {
+    listPosts: jest.fn(),
+    readPostById: jest.fn(),
+    readPostsByIds: jest.fn(),
+    existsActivePost: jest.fn(),
+    listComments: jest.fn(),
+};
+const writer = {
+    create: jest.fn(),
+    updateByAuthor: jest.fn(),
+    softDeleteByAuthor: jest.fn(),
+    incrementViewCount: jest.fn(),
+};
+/** RedisService 모의 — exists/set 만 사용 */
+const redis = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    exists: jest.fn(),
+};
+
+const useCase = new IncrementViewCountUseCase(reader as any, writer as any, redis as any);
+
+beforeEach(() => jest.clearAllMocks());
+
 describe('IncrementViewCountUseCase', () => {
-    const reader = {
-        listPosts: jest.fn(),
-        readPostById: jest.fn(),
-        readPostsByIds: jest.fn(),
-        existsActivePost: jest.fn(),
-        listComments: jest.fn(),
-    };
-    const writer = {
-        create: jest.fn(),
-        updateByAuthor: jest.fn(),
-        softDeleteByAuthor: jest.fn(),
-        incrementViewCount: jest.fn(),
-    };
-
-    const useCase = new IncrementViewCountUseCase(reader as any, writer as any);
-
-    beforeEach(() => jest.clearAllMocks());
-
     it('존재하지 않는 게시글 → BadRequestException, incrementViewCount 미호출', async () => {
         reader.existsActivePost.mockResolvedValueOnce(false);
         await expect(useCase.execute('p-missing')).rejects.toThrow(BadRequestException);
         expect(writer.incrementViewCount).not.toHaveBeenCalled();
     });
 
-    it('활성 게시글 → incrementViewCount 호출', async () => {
+    it('비인증(userId 없음) → Redis 확인 없이 항상 증가', async () => {
         reader.existsActivePost.mockResolvedValueOnce(true);
         writer.incrementViewCount.mockResolvedValueOnce(undefined);
 
-        await expect(useCase.execute('p-1')).resolves.toBeUndefined();
-        expect(reader.existsActivePost).toHaveBeenCalledWith('p-1');
+        await useCase.execute('p-1');
+
+        expect(redis.exists).not.toHaveBeenCalled();
         expect(writer.incrementViewCount).toHaveBeenCalledWith('p-1');
     });
 
-    it('동일 postId 두 번 호출 → 두 번 모두 incrementViewCount 호출 (단순 증가)', async () => {
+    it('인증 + 최초 방문 → Redis key 없음 → 증가 + key 저장', async () => {
+        reader.existsActivePost.mockResolvedValueOnce(true);
+        redis.exists.mockResolvedValueOnce(false);
+        writer.incrementViewCount.mockResolvedValueOnce(undefined);
+
+        await useCase.execute('p-1', 'u-1');
+
+        expect(redis.exists).toHaveBeenCalledWith('community:view:u-1:p-1');
+        expect(writer.incrementViewCount).toHaveBeenCalledWith('p-1');
+        expect(redis.set).toHaveBeenCalledWith('community:view:u-1:p-1', '1', 86400);
+    });
+
+    it('인증 + 이미 방문(Redis hit) → 증가 생략 (dedup)', async () => {
+        reader.existsActivePost.mockResolvedValueOnce(true);
+        redis.exists.mockResolvedValueOnce(true);
+
+        await useCase.execute('p-1', 'u-1');
+
+        expect(writer.incrementViewCount).not.toHaveBeenCalled();
+        expect(redis.set).not.toHaveBeenCalled();
+    });
+
+    it('서로 다른 사용자는 같은 게시글에 각각 증가', async () => {
         reader.existsActivePost.mockResolvedValue(true);
+        redis.exists.mockResolvedValue(false);
         writer.incrementViewCount.mockResolvedValue(undefined);
 
-        await useCase.execute('p-1');
-        await useCase.execute('p-1');
+        await useCase.execute('p-1', 'u-A');
+        await useCase.execute('p-1', 'u-B');
+
         expect(writer.incrementViewCount).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/api/community/test/e2e/community.e2e-spec.ts
+++ b/src/api/community/test/e2e/community.e2e-spec.ts
@@ -3,7 +3,7 @@ import { getConnectionToken } from '@nestjs/mongoose';
 import { Connection, Types } from 'mongoose';
 import request from 'supertest';
 
-import { createTestingApp } from '../../../../common/testing/test-utils';
+import { createTestingApp, getAdopterToken } from '../../../../common/testing/test-utils';
 
 describe('커뮤니티 종단간 테스트 (v2 read-only slice)', () => {
     let app: INestApplication;
@@ -99,6 +99,32 @@ describe('커뮤니티 종단간 테스트 (v2 read-only slice)', () => {
             expect(card.category).toBe('레오파드');
         });
 
+        it('비인증 목록 조회 — isSaved: false (저장 여부 미확인)', async () => {
+            await seedPost();
+            const res = await request(app.getHttpServer()).get('/api/v2/community/posts').expect(200);
+
+            expect(res.body.data.items[0].isSaved).toBe(false);
+        });
+
+        it('인증 + 북마크 된 게시글 → isSaved: true', async () => {
+            const postId = await seedPost();
+            const tokenRes = await getAdopterToken(app);
+            expect(tokenRes).not.toBeNull();
+
+            // 북마크 추가
+            await request(app.getHttpServer())
+                .post(`/api/v2/community/posts/${postId}/bookmark`)
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/v2/community/posts')
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+
+            expect(res.body.data.items[0].isSaved).toBe(true);
+        });
+
         it('petType 필터 — 다른 종류는 제외', async () => {
             await seedPost({ petType: 'dog', category: '비숑' });
             await seedPost({ petType: 'reptile', category: '레오파드' });
@@ -140,6 +166,30 @@ describe('커뮤니티 종단간 테스트 (v2 read-only slice)', () => {
             expect(res.body.data.body.length).toBe(200);
             expect(res.body.data.commentPreview).toHaveLength(5);
         });
+
+        it('비인증 상세 조회 — isSaved: false', async () => {
+            const postId = await seedPost();
+            const res = await request(app.getHttpServer()).get(`/api/v2/community/posts/${postId}`).expect(200);
+            expect(res.body.data.isSaved).toBe(false);
+        });
+
+        it('인증 + 북마크 된 게시글 상세 → isSaved: true', async () => {
+            const postId = await seedPost();
+            const tokenRes = await getAdopterToken(app);
+            expect(tokenRes).not.toBeNull();
+
+            await request(app.getHttpServer())
+                .post(`/api/v2/community/posts/${postId}/bookmark`)
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+
+            const res = await request(app.getHttpServer())
+                .get(`/api/v2/community/posts/${postId}`)
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+
+            expect(res.body.data.isSaved).toBe(true);
+        });
     });
 
     describe('POST /api/v2/community/posts/:postId/view', () => {
@@ -178,7 +228,7 @@ describe('커뮤니티 종단간 테스트 (v2 read-only slice)', () => {
                 .expect(400);
         });
 
-        it('동일 게시글 두 번 호출 → viewCount 2 증가 (단순 증가, dedup 없음)', async () => {
+        it('비인증 동일 게시글 두 번 호출 → viewCount 2 (비인증은 dedup 없음)', async () => {
             const postId = await seedPost({ viewCount: 0 });
 
             await request(app.getHttpServer()).post(`/api/v2/community/posts/${postId}/view`).expect(200);
@@ -186,6 +236,24 @@ describe('커뮤니티 종단간 테스트 (v2 read-only slice)', () => {
 
             const doc = await connection.collection('community_posts').findOne({ _id: new Types.ObjectId(postId) });
             expect(doc?.viewCount).toBe(2);
+        });
+
+        it('인증된 사용자 동일 게시글 두 번 호출 → viewCount 1 (dedup 적용)', async () => {
+            const postId = await seedPost({ viewCount: 0 });
+            const tokenRes = await getAdopterToken(app);
+            expect(tokenRes).not.toBeNull();
+
+            await request(app.getHttpServer())
+                .post(`/api/v2/community/posts/${postId}/view`)
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+            await request(app.getHttpServer())
+                .post(`/api/v2/community/posts/${postId}/view`)
+                .set('Authorization', `Bearer ${tokenRes!.token}`)
+                .expect(200);
+
+            const doc = await connection.collection('community_posts').findOne({ _id: new Types.ObjectId(postId) });
+            expect(doc?.viewCount).toBe(1);
         });
 
         it('잘못된 ObjectId 포맷 → 400 (게시글 없음으로 처리)', async () => {


### PR DESCRIPTION
## Summary
- § 3.12 커뮤니티 이슈 #135, #137 잔여 항목 구현
- 게시글 목록/상세 응답에 `isSaved` 필드 누락 수정 — 저장 여부를 프론트가 판단할 수 없던 문제 해결
- `POST /view` 조회 수 중복 방지 — 인증 사용자 24시간 Redis dedup으로 새로고침 조작 차단
- TDD (RED → GREEN → E2E) 방식 / 단위 테스트 61개, E2E 75개 전부 통과

## 주요 구현 내용

**[#135] isSaved 필드 누락 수정**
- `CommunityPostCardResponseDto`, `CommunityPostDetailResponseDto`에 `isSaved: boolean` 필드 추가
- `GetCommunityPostListUseCase`: `COMMUNITY_BOOKMARK_PORT` 주입, `findLikedPostIds`와 함께 `findSavedPostIds` 배치 조회를 `Promise.all` 병렬 처리 (N+1 방지)
- `GetCommunityPostDetailUseCase`: `findSavedPostIds([postId])`를 기존 `Promise.all`에 추가
- 비인증 요청은 `bookmarkPort` 호출 없이 `isSaved: false` 반환

**[#137] 조회 수 중복 방지**
- `IncrementViewCountUseCase`: `REDIS_SERVICE_TOKEN` 주입, `userId` 파라미터 추가
  - 인증 사용자: `community:view:{userId}:{postId}` 키 Redis 확인 → hit 시 skip, miss 시 증가 후 TTL 86400s 저장
  - 비인증 사용자: 기존과 동일하게 항상 증가
- `CommunityPostViewCountController`: `@CurrentUser('userId') userId?: string` 추가 (기존 `OptionalJwtAuthGuard` 재활용, Guard 변경 없음)

## 영향 범위
- Breaking Change 없음 — 기존 API 응답에 필드 추가만, 제거·변경 없음
- `isSaved` 필드 미사용 시 무시하면 되므로 프론트 즉시 배포 불필요
- Redis 미연결 환경(로컬)도 인메모리 폴백으로 dedup 정상 동작

## Test Plan

### 단위 테스트 (Unit)
- [x] `GetCommunityPostListUseCase` — 비인증 시 `isSaved: false` + `findSavedPostIds` 미호출
- [x] `GetCommunityPostListUseCase` — 인증 + 저장된 게시글 → `isSaved: true`, 저장 안 한 게시글 → `isSaved: false`
- [x] `GetCommunityPostDetailUseCase` — 비인증 시 `isSaved: false` + `findSavedPostIds` 미호출
- [x] `GetCommunityPostDetailUseCase` — 인증 + 저장 여부에 따라 `isSaved` 정확히 반환
- [x] `IncrementViewCountUseCase` — 비인증 시 Redis 미호출, 항상 증가
- [x] `IncrementViewCountUseCase` — 인증 + 최초 방문 → 증가 + Redis key 저장
- [x] `IncrementViewCountUseCase` — 인증 + 재방문(Redis hit) → 증가 생략
- [x] `IncrementViewCountUseCase` — 다른 사용자는 같은 게시글도 각각 증가

### E2E 테스트
- [x] `GET /api/v2/community/posts` 비인증 → `isSaved: false`
- [x] `GET /api/v2/community/posts` 인증 + 북마크 후 조회 → `isSaved: true`
- [x] `GET /api/v2/community/posts/:postId` 비인증 → `isSaved: false`
- [x] `GET /api/v2/community/posts/:postId` 인증 + 북마크 후 조회 → `isSaved: true`
- [x] `POST /api/v2/community/posts/:postId/view` 비인증 2회 → `viewCount: 2`
- [x] `POST /api/v2/community/posts/:postId/view` 인증 2회 → `viewCount: 1` (dedup)