### PR TITLE
fix(v2): 브리더 탐색 petType 옵션화 및 콘테스트 목록 페이지네이션 표준화

### DIFF
--- a/src/api/breeder/application/types/breeder-search-query.type.ts
+++ b/src/api/breeder/application/types/breeder-search-query.type.ts
@@ -15,7 +15,7 @@ export type BreederSearchQuery = {
 };
 
 export type BreederExploreQuery = {
-    petType: PetType | string;
+    petType?: PetType | string;
     dogSize?: Array<PetSize | string>;
     catFurLength?: Array<FurLength | string>;
     breeds?: string[];

--- a/src/api/breeder/domain/services/breeder-explore-criteria.service.ts
+++ b/src/api/breeder/domain/services/breeder-explore-criteria.service.ts
@@ -27,9 +27,15 @@ export class BreederExploreCriteriaService {
         const filter: Record<string, unknown> = {
             'verification.status': 'approved',
             accountStatus: 'active',
-            petType,
             isTestAccount: { $ne: true },
         };
+
+        // petType은 값이 있을 때만 필터에 추가한다.
+        // (undefined를 그대로 넣으면 드라이버가 { petType: null }로 변환해
+        //  petType이 설정된 브리더가 전부 제외되어 결과가 0건이 되는 버그가 있었음)
+        if (petType) {
+            filter['petType'] = petType;
+        }
 
         if (breeds && breeds.length > 0) {
             filter['breeds'] = { $in: breeds };

--- a/src/api/breeder/dto/request/search-breeder-request.dto.ts
+++ b/src/api/breeder/dto/request/search-breeder-request.dto.ts
@@ -10,13 +10,14 @@ export class SearchBreederRequestDto {
      * 반려동물 타입 (강아지/고양이)
      * @example "dog"
      */
-    @ApiProperty({
-        description: '반려동물 타입',
+    @ApiPropertyOptional({
+        description: '반려동물 타입 (미지정 시 전체 조회)',
         enum: PetType,
         example: 'dog',
     })
+    @IsOptional()
     @IsEnum(PetType)
-    petType: string;
+    petType?: string;
 
     /**
      * 강아지 크기 필터 (소형/중형/대형) - 중복 선택 가능

--- a/src/api/contest/controller/contest-entries.controller.ts
+++ b/src/api/contest/controller/contest-entries.controller.ts
@@ -26,6 +26,20 @@ export class ContestEntriesController {
             limit: Number(limit),
             userId,
         });
-        return ApiResponseDto.success(result, '콘테스트 항목 조회 완료');
+        const totalPages = Math.ceil(result.total / result.limit) || 0;
+        return ApiResponseDto.success(
+            {
+                items: result.items,
+                pagination: {
+                    currentPage: result.page,
+                    pageSize: result.limit,
+                    totalItems: result.total,
+                    totalPages,
+                    hasNextPage: result.page < totalPages,
+                    hasPrevPage: result.page > 1,
+                },
+            },
+            '콘테스트 항목 조회 완료',
+        );
     }
 }

--- a/src/api/contest/controller/contest-hall-of-fame.controller.ts
+++ b/src/api/contest/controller/contest-hall-of-fame.controller.ts
@@ -17,6 +17,20 @@ export class ContestHallOfFameController {
     @ApiGetHallOfFameEndpoint()
     async getHallOfFame(@Query('page') page = 1, @Query('limit') limit = 10): Promise<ApiResponseDto<unknown>> {
         const result = await this.getHallOfFameUseCase.execute({ page: Number(page), limit: Number(limit) });
-        return ApiResponseDto.success(result, '명예의 전당 조회 완료');
+        const totalPages = Math.ceil(result.total / result.limit) || 0;
+        return ApiResponseDto.success(
+            {
+                items: result.items,
+                pagination: {
+                    currentPage: result.page,
+                    pageSize: result.limit,
+                    totalItems: result.total,
+                    totalPages,
+                    hasNextPage: result.page < totalPages,
+                    hasPrevPage: result.page > 1,
+                },
+            },
+            '명예의 전당 조회 완료',
+        );
     }
 }


### PR DESCRIPTION
Closes #158

## 변경 사항

### 브리더 탐색 (`§ 3.11`)
- 탐색 요청 DTO의 `petType`을 **필수 → 선택**으로 변경하고, 값이 있을 때만 쿼리 필터에 추가
- 카테고리 '전체'(petType 미지정) 요청 시 두 가지 버그 해결:
  - `@IsEnum` 검증 실패로 **400** 반환
  - `{ petType: undefined }` → 드라이버가 `{ petType: null }`로 변환 → petType이 설정된 브리더 전부 제외되어 **결과 0건**

### 콘테스트 목록 (`§ 3.13`)
- `GET /contest/entries`, `GET /contest/hall-of-fame` 응답을 **표준 페이지네이션 형태로 정렬**
- `{ items, total, page, limit }` → `{ items, pagination: { currentPage, pageSize, totalItems, totalPages, hasNextPage, hasPrevPage } }`
- v2 전 도메인이 쓰는 공통 `PaginationResponseDto`/`PageInfoDto`와 일치 (프론트 무한쿼리가 `pagination`을 기대하는데 없어 `Cannot read properties of undefined (hasNextPage)` 런타임 에러나던 문제 해결)

## 배경
프론트 화면 연동 중 발견한 v2 응답/검증 정합성 버그. 별도 스펙 이슈 없이 통합 과정에서 수정.

## 테스트 방법
1. `POST /api/v2/breeder/explore` — body 없이 / `{"petType":"dog"}` 둘 다 200, 미지정 시 승인·active 브리더 전체 반환
2. `GET /api/v2/contest/entries?page=1&limit=15` → `data.pagination` 6필드 정상
3. `GET /api/v2/contest/hall-of-fame?page=1&limit=10` → 동일

## 비고
- v2 페이지네이션은 `{ items, pagination: {currentPage, pageSize, totalItems, totalPages, hasNextPage, hasPrevPage} }` **단일 포맷**으로 통일됨을 확인 (콘테스트가 유일한 예외였고 본 PR로 정렬)