### PR TITLE
fix(breeder-management): 브리더 프로필 응답 profileInfo 필드명 프론트 계약 정렬

### DIFF
--- a/src/api/breeder-management/domain/services/breeder-management-profile-assembler.service.ts
+++ b/src/api/breeder-management/domain/services/breeder-management-profile-assembler.service.ts
@@ -29,15 +29,25 @@ export class BreederManagementProfileAssemblerService {
         const priceRange = breeder.profile?.priceRange;
         const priceRangeMin = priceRange?.min ?? 0;
         const priceRangeMax = priceRange?.max ?? 0;
+        // profileInfo는 프론트 계약(BreederProfileInfoDto)에 맞춘 필드명으로 반환한다.
+        // (스키마: description/location{city,district}/representativePhotos/specialization/priceRange{min,max}
+        //  → 응답: profileDescription/locationInfo{cityName,districtName}/profilePhotos/specializationAreas/priceRangeInfo{minPrice,maxPrice})
         const profileWithSignedUrls = breeder.profile
             ? {
-                  ...breeder.profile,
-                  representativePhotos: fileUrlPort.generateMany(breeder.profile.representativePhotos || [], 60),
-                  priceRange: !priceRange
-                      ? { min: 0, max: 0, display: 'not_set' }
+                  profileDescription: breeder.profile.description ?? '',
+                  locationInfo: {
+                      cityName: breeder.profile.location?.city ?? '',
+                      districtName: breeder.profile.location?.district ?? '',
+                      detailAddress: breeder.profile.location?.address || undefined,
+                  },
+                  profilePhotos: fileUrlPort.generateMany(breeder.profile.representativePhotos || [], 60),
+                  specializationAreas: breeder.profile.specialization ?? [],
+                  experienceYears: breeder.profile.experienceYears,
+                  priceRangeInfo: !priceRange
+                      ? { minPrice: 0, maxPrice: 0, display: 'not_set' }
                       : {
-                            min: priceRangeMin,
-                            max: priceRangeMax,
+                            minPrice: priceRangeMin,
+                            maxPrice: priceRangeMax,
                             display:
                                 priceRange.display || (priceRangeMin > 0 || priceRangeMax > 0 ? 'range' : 'not_set'),
                         },

--- a/src/api/breeder-management/test/domain/services/breeder-management-profile-assembler.service.spec.ts
+++ b/src/api/breeder-management/test/domain/services/breeder-management-profile-assembler.service.spec.ts
@@ -37,7 +37,7 @@ describe('BreederManagementProfileAssemblerService', () => {
         const result = service.toResponse(makeBreeder(), [], [], fileUrlPort);
         expect(result.authProvider).toBe('kakao');
         expect(result.marketingAgreed).toBe(true);
-        expect((result.profileInfo as any)?.priceRange).toEqual({ min: 100, max: 300, display: 'range' });
+        expect((result.profileInfo as any)?.priceRangeInfo).toEqual({ minPrice: 100, maxPrice: 300, display: 'range' });
         expect((result.verificationInfo as any)?.documents[0].url).toBe('https://cdn/verification/id.pdf');
     });
 
@@ -54,7 +54,7 @@ describe('BreederManagementProfileAssemblerService', () => {
 
     it('priceRange이 없으면 not_set', () => {
         const result = service.toResponse(makeBreeder({ profile: { representativePhotos: [] } }), [], [], fileUrlPort);
-        expect((result.profileInfo as any)?.priceRange).toEqual({ min: 0, max: 0, display: 'not_set' });
+        expect((result.profileInfo as any)?.priceRangeInfo).toEqual({ minPrice: 0, maxPrice: 0, display: 'not_set' });
     });
 
     it('consultationAgreed 기본값은 true', () => {


### PR DESCRIPTION
Closes #159

## 변경 사항
- `breeder-management/profile` 응답의 `profileInfo` 필드명을 프론트 계약(`BreederProfileInfoDto`)·자체 README에 맞춰 정렬
  - `description` → `profileDescription`
  - `location{city,district}` → `locationInfo{cityName,districtName,detailAddress}`
  - `representativePhotos` → `profilePhotos`
  - `priceRange{min,max}` → `priceRangeInfo{minPrice,maxPrice,display}`
  - `specialization` → `specializationAreas`, `experienceYears` 포함
- 어셈블러 스펙 테스트 갱신 (breeder-management 178 tests green)

## 배경
프론트 E2E 자동화 스윕에서 마이홈(브리더) 런타임 크래시(`cityName of undefined`)로 발견.

## 테스트
1. `GET /api/v2/breeder-management/profile` (브리더 토큰) → profileInfo가 profileDescription/locationInfo/... 반환
2. 마이홈(브리더) 페이지 런타임 에러 없음