### PR TITLE
fix(notification): 기기 핸드오프 시 옛 계정에 푸시 토큰 잔존 문제 수정

### DIFF
--- a/src/api/adopter/repository/adopter.repository.ts
+++ b/src/api/adopter/repository/adopter.repository.ts
@@ -341,6 +341,20 @@ export class AdopterRepository {
     }
 
     /**
+     * 동일 FCM 토큰을 가진 모든 입양자에서 해당 토큰을 제거한다.
+     * 기기 핸드오프(같은 폰에서 다른 계정 재로그인) 대응: 디바이스 토큰 1개는
+     * 마지막 로그인 계정 1명에게만 속하도록, 등록 직전 전역에서 먼저 제거한다.
+     *
+     * @param token 제거할 FCM 디바이스 토큰
+     */
+    async removePushDeviceTokenFromAllUsers(token: string): Promise<void> {
+        if (!token) return;
+        await this.adopterModel
+            .updateMany({ 'pushDeviceTokens.token': token }, { $pull: { pushDeviceTokens: { token } } })
+            .exec();
+    }
+
+    /**
      * 입양자의 활성 디바이스 푸시 토큰 문자열 목록 조회.
      *
      * @param adopterId 입양자 ID

--- a/src/api/breeder-management/repository/breeder.repository.ts
+++ b/src/api/breeder-management/repository/breeder.repository.ts
@@ -427,6 +427,20 @@ export class BreederRepository {
     }
 
     /**
+     * 동일 FCM 토큰을 가진 모든 브리더에서 해당 토큰을 제거한다.
+     * 기기 핸드오프(같은 폰에서 다른 계정 재로그인) 대응: 디바이스 토큰 1개는
+     * 마지막 로그인 계정 1명에게만 속하도록, 등록 직전 전역에서 먼저 제거한다.
+     *
+     * @param token 제거할 FCM 디바이스 토큰
+     */
+    async removePushDeviceTokenFromAllUsers(token: string): Promise<void> {
+        if (!token) return;
+        await this.breederModel
+            .updateMany({ 'pushDeviceTokens.token': token }, { $pull: { pushDeviceTokens: { token } } })
+            .exec();
+    }
+
+    /**
      * 브리더의 활성 디바이스 푸시 토큰 문자열 목록 조회.
      *
      * @param breederId 브리더 ID

--- a/src/api/notification/infrastructure/notification-push-token-mongoose.adapter.ts
+++ b/src/api/notification/infrastructure/notification-push-token-mongoose.adapter.ts
@@ -27,6 +27,14 @@ export class NotificationPushTokenMongooseAdapter implements NotificationPushTok
     ) {}
 
     async register(command: RegisterPushDeviceTokenCommand): Promise<void> {
+        // 기기 핸드오프 대응: 같은 디바이스에서 다른 계정으로 재로그인하면 옛 계정에
+        // 토큰이 남아 잘못 전달되므로, 등록 직전 adopter/breeder 전체에서 동일 토큰을
+        // 먼저 제거한다. 디바이스 토큰 1개는 마지막 로그인 계정 1명에게만 속한다.
+        await Promise.all([
+            this.adopterRepository.removePushDeviceTokenFromAllUsers(command.token),
+            this.breederRepository.removePushDeviceTokenFromAllUsers(command.token),
+        ]);
+
         if (command.userRole === 'adopter') {
             await this.adopterRepository.upsertPushDeviceToken(
                 command.userId,

--- a/src/api/notification/test/infrastructure/notification-push-token-mongoose.adapter.spec.ts
+++ b/src/api/notification/test/infrastructure/notification-push-token-mongoose.adapter.spec.ts
@@ -1,0 +1,66 @@
+import { NotificationPushTokenMongooseAdapter } from '../../infrastructure/notification-push-token-mongoose.adapter';
+import type { AdopterRepository } from '../../../adopter/repository/adopter.repository';
+import type { BreederRepository } from '../../../breeder-management/repository/breeder.repository';
+import type { RegisterPushDeviceTokenCommand } from '../../application/ports/notification-push-token-store.port';
+
+describe('푸시 토큰 스토어 어댑터 - 기기 핸드오프', () => {
+    let adopterRepository: jest.Mocked<Pick<AdopterRepository, 'upsertPushDeviceToken' | 'removePushDeviceTokenFromAllUsers'>>;
+    let breederRepository: jest.Mocked<Pick<BreederRepository, 'upsertPushDeviceToken' | 'removePushDeviceTokenFromAllUsers'>>;
+    let adapter: NotificationPushTokenMongooseAdapter;
+
+    const command: RegisterPushDeviceTokenCommand = {
+        userId: 'adopter-1',
+        userRole: 'adopter',
+        token: 'fcm-token-handoff-test',
+        platform: 'android',
+        appVersion: '1.0.0',
+    };
+
+    beforeEach(() => {
+        adopterRepository = {
+            upsertPushDeviceToken: jest.fn().mockResolvedValue(undefined),
+            removePushDeviceTokenFromAllUsers: jest.fn().mockResolvedValue(undefined),
+        };
+        breederRepository = {
+            upsertPushDeviceToken: jest.fn().mockResolvedValue(undefined),
+            removePushDeviceTokenFromAllUsers: jest.fn().mockResolvedValue(undefined),
+        };
+        adapter = new NotificationPushTokenMongooseAdapter(
+            adopterRepository as unknown as AdopterRepository,
+            breederRepository as unknown as BreederRepository,
+        );
+    });
+
+    it('등록 시 adopter/breeder 전체에서 동일 토큰을 먼저 제거한다', async () => {
+        await adapter.register(command);
+
+        expect(adopterRepository.removePushDeviceTokenFromAllUsers).toHaveBeenCalledWith(command.token);
+        expect(breederRepository.removePushDeviceTokenFromAllUsers).toHaveBeenCalledWith(command.token);
+    });
+
+    it('전역 제거 후 현재 유저(adopter)에 토큰을 upsert 한다', async () => {
+        await adapter.register(command);
+
+        expect(adopterRepository.upsertPushDeviceToken).toHaveBeenCalledWith(
+            command.userId,
+            command.token,
+            command.platform,
+            command.appVersion,
+        );
+        expect(breederRepository.upsertPushDeviceToken).not.toHaveBeenCalled();
+    });
+
+    it('breeder 역할이면 breeder 에 upsert 한다 (전역 제거는 동일)', async () => {
+        await adapter.register({ ...command, userRole: 'breeder', userId: 'breeder-1' });
+
+        expect(adopterRepository.removePushDeviceTokenFromAllUsers).toHaveBeenCalledWith(command.token);
+        expect(breederRepository.removePushDeviceTokenFromAllUsers).toHaveBeenCalledWith(command.token);
+        expect(breederRepository.upsertPushDeviceToken).toHaveBeenCalledWith(
+            'breeder-1',
+            command.token,
+            command.platform,
+            command.appVersion,
+        );
+        expect(adopterRepository.upsertPushDeviceToken).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #161

## 변경 사항
- 푸시 토큰 등록 시 `adopter`/`breeder` 전체에서 동일 FCM 토큰을 먼저 제거 후 현재 유저에 추가
- `AdopterRepository.removePushDeviceTokenFromAllUsers`, `BreederRepository.removePushDeviceTokenFromAllUsers` 추가 (`updateMany $pull`)
- `NotificationPushTokenMongooseAdapter.register`에서 upsert 직전 전역 제거 수행
- 어댑터 단위 테스트 추가 (전역 제거 → 현재 유저 upsert 검증)

## 배경
같은 디바이스에서 계정 A 로그아웃 → 계정 B 로그인 시, 그 디바이스의 FCM 토큰이 A의 `pushDeviceTokens`에 그대로 남아 어드민이 A에게 보낸 푸시가 B의 폰으로 잘못 전달되던 문제. 로그아웃이 토큰을 해제하지 않고 등록이 해당 유저만 갱신했기 때문. (Mongo만으로 해결, Redis 불필요)

## 인수 조건 체크
- [x] register 시 다른 모든 유저(adopter+breeder)에서 동일 토큰 제거
- [x] 현재 유저에는 정상 upsert (중복 없음)
- [x] 응답 계약/기존 동작 변화 없음
- [x] 단위 테스트 (14 passed)

## 테스트 방법
1. 폰에서 계정 A 로그인 → 토큰 등록 확인
2. 같은 폰에서 A 로그아웃 → 계정 B 로그인 → 토큰이 B로 이동, A에서 제거 확인
3. 어드민에서 A로 발송 → 그 폰에 안 옴 / B로 발송 → 옴