### PR TITLE
feat(chat): 채팅 응답 계약을 화면 렌더링 중심으로 정리

### DIFF
--- a/src/api/chat/application/ports/chat-message-manager.port.ts
+++ b/src/api/chat/application/ports/chat-message-manager.port.ts
@@ -26,4 +26,5 @@ export interface ChatMessageManagerPort {
     }): Promise<ChatMessageSnapshot>;
     findMessagesByRoomId(roomId: string, limit: number, before?: Date): Promise<ChatMessageSnapshot[]>;
     markMessagesAsRead(roomId: string, receiverId: string): Promise<void>;
+    countUnreadMessages(roomId: string, receiverId: string): Promise<number>;
 }

--- a/src/api/chat/application/ports/chat-participant-reader.port.ts
+++ b/src/api/chat/application/ports/chat-participant-reader.port.ts
@@ -1,0 +1,14 @@
+import { SenderRole } from '../../../../schema/chat-message.schema';
+
+export type ChatParticipantProfileSnapshot = {
+    userId: string;
+    role: SenderRole;
+    nickname: string;
+    profileImageUrl?: string;
+};
+
+export const CHAT_PARTICIPANT_READER = Symbol('CHAT_PARTICIPANT_READER');
+
+export interface ChatParticipantReaderPort {
+    findProfile(userId: string, role: SenderRole): Promise<ChatParticipantProfileSnapshot | null>;
+}

--- a/src/api/chat/application/types/chat-room-result.type.ts
+++ b/src/api/chat/application/types/chat-room-result.type.ts
@@ -1,0 +1,20 @@
+import { ChatRoomStatus } from '../../../../schema/chat-room.schema';
+import { SenderRole } from '../../../../schema/chat-message.schema';
+
+export type ChatRoomCounterpartResult = {
+    userId: string;
+    role: SenderRole;
+    nickname: string;
+    profileImageUrl?: string;
+};
+
+export type ChatRoomResult = {
+    roomId: string;
+    applicationId?: string;
+    status: ChatRoomStatus;
+    counterpart: ChatRoomCounterpartResult;
+    lastMessage?: string;
+    lastMessageAt?: string;
+    unreadCount: number;
+    createdAt: string;
+};

--- a/src/api/chat/application/use-cases/get-my-rooms.use-case.ts
+++ b/src/api/chat/application/use-cases/get-my-rooms.use-case.ts
@@ -1,18 +1,21 @@
 import { Injectable, Inject } from '@nestjs/common';
 
-import { CHAT_ROOM_MANAGER, type ChatRoomManagerPort, type ChatRoomSnapshot } from '../ports/chat-room-manager.port';
+import { CHAT_ROOM_MANAGER, type ChatRoomManagerPort } from '../ports/chat-room-manager.port';
 import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
 import { SenderRole } from '../../../../schema/chat-message.schema';
+import { ChatRoomResponseAssemblerService } from '../../domain/services/chat-room-response-assembler.service';
+import type { ChatRoomResult } from '../types/chat-room-result.type';
 
 @Injectable()
 export class GetMyRoomsUseCase {
     constructor(
         @Inject(CHAT_ROOM_MANAGER)
         private readonly chatRoomManager: ChatRoomManagerPort,
+        private readonly chatRoomResponseAssembler: ChatRoomResponseAssemblerService,
         private readonly logger: CustomLoggerService,
     ) {}
 
-    async execute(userId: string, role: SenderRole): Promise<ChatRoomSnapshot[]> {
+    async execute(userId: string, role: SenderRole): Promise<ChatRoomResult[]> {
         this.logger.logStart('getMyRooms', '내 채팅방 목록 조회 시작', { userId, role });
 
         try {
@@ -22,7 +25,7 @@ export class GetMyRoomsUseCase {
                     : await this.chatRoomManager.findRoomsByBreederId(userId);
 
             this.logger.logSuccess('getMyRooms', '내 채팅방 목록 조회 완료', { userId, count: rooms.length });
-            return rooms;
+            return this.chatRoomResponseAssembler.toResults(rooms, userId, role);
         } catch (error) {
             this.logger.logError('getMyRooms', '내 채팅방 목록 조회', error);
             throw error;

--- a/src/api/chat/chat.module.ts
+++ b/src/api/chat/chat.module.ts
@@ -5,6 +5,9 @@ import { ConfigService } from '@nestjs/config';
 
 import { ChatRoom, ChatRoomSchema } from '../../schema/chat-room.schema';
 import { ChatMessage, ChatMessageSchema } from '../../schema/chat-message.schema';
+import { Adopter, AdopterSchema } from '../../schema/adopter.schema';
+import { Breeder, BreederSchema } from '../../schema/breeder.schema';
+import { StorageModule } from '../../common/storage/storage.module';
 
 import { ChatRoomCommandController } from './controller/chat-room-command.controller';
 import { ChatRoomQueryController } from './controller/chat-room-query.controller';
@@ -17,6 +20,7 @@ import { KafkaChatMessageBrokerAdapter } from './infrastructure/kafka-chat-messa
 import { ChatPolicyService } from './domain/services/chat-policy.service';
 import { ChatRoomMapperService } from './domain/services/chat-room-mapper.service';
 import { ChatMessageMapperService } from './domain/services/chat-message-mapper.service';
+import { ChatRoomResponseAssemblerService } from './domain/services/chat-room-response-assembler.service';
 
 import { CreateOrGetRoomUseCase } from './application/use-cases/create-or-get-room.use-case';
 import { GetMyRoomsUseCase } from './application/use-cases/get-my-rooms.use-case';
@@ -27,6 +31,8 @@ import { CloseRoomUseCase } from './application/use-cases/close-room.use-case';
 import { CHAT_ROOM_MANAGER } from './application/ports/chat-room-manager.port';
 import { CHAT_MESSAGE_MANAGER } from './application/ports/chat-message-manager.port';
 import { CHAT_MESSAGE_BROKER } from './application/ports/chat-message-broker.port';
+import { CHAT_PARTICIPANT_READER } from './application/ports/chat-participant-reader.port';
+import { ChatParticipantMongooseReaderAdapter } from './infrastructure/chat-participant-mongoose-reader.adapter';
 import {
     CREATE_OR_GET_ROOM_USE_CASE,
     GET_MY_ROOMS_USE_CASE,
@@ -40,7 +46,10 @@ import {
         MongooseModule.forFeature([
             { name: ChatRoom.name, schema: ChatRoomSchema },
             { name: ChatMessage.name, schema: ChatMessageSchema },
+            { name: Adopter.name, schema: AdopterSchema },
+            { name: Breeder.name, schema: BreederSchema },
         ]),
+        StorageModule,
         JwtModule.registerAsync({
             useFactory: (configService: ConfigService) => ({
                 secret: configService.get<string>('JWT_SECRET'),
@@ -57,15 +66,18 @@ import {
         ChatPolicyService,
         ChatRoomMapperService,
         ChatMessageMapperService,
+        ChatRoomResponseAssemblerService,
 
         // Adapters
         ChatMongooseManagerAdapter,
         KafkaChatMessageBrokerAdapter,
+        ChatParticipantMongooseReaderAdapter,
 
         // Port → Adapter 바인딩
         { provide: CHAT_ROOM_MANAGER, useExisting: ChatMongooseManagerAdapter },
         { provide: CHAT_MESSAGE_MANAGER, useExisting: ChatMongooseManagerAdapter },
         { provide: CHAT_MESSAGE_BROKER, useExisting: KafkaChatMessageBrokerAdapter },
+        { provide: CHAT_PARTICIPANT_READER, useExisting: ChatParticipantMongooseReaderAdapter },
 
         // Use Cases
         CreateOrGetRoomUseCase,

--- a/src/api/chat/controller/chat-room-command.controller.ts
+++ b/src/api/chat/controller/chat-room-command.controller.ts
@@ -9,8 +9,10 @@ import { CurrentUser } from '../../../common/decorator/user.decorator';
 import { CreateOrGetRoomUseCase } from '../application/use-cases/create-or-get-room.use-case';
 import { CloseRoomUseCase } from '../application/use-cases/close-room.use-case';
 import { ChatPolicyService } from '../domain/services/chat-policy.service';
+import { ChatRoomResponseAssemblerService } from '../domain/services/chat-room-response-assembler.service';
 import { CreateRoomRequestDto } from '../dto/request/create-room-request.dto';
 import { ApiCreateOrGetRoomEndpoint, ApiCloseRoomEndpoint } from '../swagger';
+import { SenderRole } from '../../../schema/chat-message.schema';
 
 @ApiTags('채팅')
 @Controller('chat')
@@ -20,6 +22,7 @@ export class ChatRoomCommandController {
         private readonly createOrGetRoomUseCase: CreateOrGetRoomUseCase,
         private readonly closeRoomUseCase: CloseRoomUseCase,
         private readonly chatPolicyService: ChatPolicyService,
+        private readonly chatRoomResponseAssembler: ChatRoomResponseAssemblerService,
     ) {}
 
     @Post('rooms')
@@ -32,7 +35,7 @@ export class ChatRoomCommandController {
             breederId: dto.breederId,
             applicationId: dto.applicationId,
         });
-        return room;
+        return this.chatRoomResponseAssembler.toResult(room, user.userId, SenderRole.ADOPTER);
     }
 
     @Delete('rooms/:roomId')

--- a/src/api/chat/controller/chat-room-query.controller.ts
+++ b/src/api/chat/controller/chat-room-query.controller.ts
@@ -38,6 +38,16 @@ export class ChatRoomQueryController {
         @Query('before') before?: string,
     ) {
         const beforeDate = before ? new Date(before) : undefined;
-        return this.getMessagesUseCase.execute(user.userId, { roomId, limit, before: beforeDate });
+        const messages = await this.getMessagesUseCase.execute(user.userId, { roomId, limit, before: beforeDate });
+        return messages.map((message) => ({
+            messageId: message.id,
+            roomId: message.roomId,
+            senderRole: message.senderRole,
+            isMine: message.senderId === user.userId,
+            content: message.content,
+            messageType: message.messageType,
+            isRead: message.isRead,
+            createdAt: message.createdAt.toISOString(),
+        }));
     }
 }

--- a/src/api/chat/domain/services/chat-room-response-assembler.service.ts
+++ b/src/api/chat/domain/services/chat-room-response-assembler.service.ts
@@ -1,0 +1,52 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { SenderRole } from '../../../../schema/chat-message.schema';
+import { type ChatRoomSnapshot } from '../../application/ports/chat-room-manager.port';
+import {
+    CHAT_MESSAGE_MANAGER,
+    type ChatMessageManagerPort,
+} from '../../application/ports/chat-message-manager.port';
+import {
+    CHAT_PARTICIPANT_READER,
+    type ChatParticipantReaderPort,
+} from '../../application/ports/chat-participant-reader.port';
+import type { ChatRoomResult } from '../../application/types/chat-room-result.type';
+
+@Injectable()
+export class ChatRoomResponseAssemblerService {
+    constructor(
+        @Inject(CHAT_MESSAGE_MANAGER)
+        private readonly chatMessageManager: ChatMessageManagerPort,
+        @Inject(CHAT_PARTICIPANT_READER)
+        private readonly participantReader: ChatParticipantReaderPort,
+    ) {}
+
+    async toResult(room: ChatRoomSnapshot, viewerId: string, viewerRole: SenderRole): Promise<ChatRoomResult> {
+        const counterpartRole = viewerRole === SenderRole.ADOPTER ? SenderRole.BREEDER : SenderRole.ADOPTER;
+        const counterpartId = counterpartRole === SenderRole.BREEDER ? room.breederId : room.adopterId;
+
+        const [counterpartProfile, unreadCount] = await Promise.all([
+            this.participantReader.findProfile(counterpartId, counterpartRole),
+            this.chatMessageManager.countUnreadMessages(room.id, viewerId),
+        ]);
+
+        return {
+            roomId: room.id,
+            applicationId: room.applicationId,
+            status: room.status,
+            counterpart: counterpartProfile ?? {
+                userId: counterpartId,
+                role: counterpartRole,
+                nickname: '알 수 없음',
+            },
+            lastMessage: room.lastMessage,
+            lastMessageAt: room.lastMessageAt?.toISOString(),
+            unreadCount,
+            createdAt: room.createdAt.toISOString(),
+        };
+    }
+
+    async toResults(rooms: ChatRoomSnapshot[], viewerId: string, viewerRole: SenderRole): Promise<ChatRoomResult[]> {
+        return Promise.all(rooms.map((room) => this.toResult(room, viewerId, viewerRole)));
+    }
+}

--- a/src/api/chat/dto/response/chat-message-response.dto.ts
+++ b/src/api/chat/dto/response/chat-message-response.dto.ts
@@ -8,11 +8,11 @@ export class ChatMessageResponseDto {
     @ApiProperty()
     roomId: string;
 
-    @ApiProperty()
-    senderId: string;
-
     @ApiProperty({ enum: SenderRole })
     senderRole: SenderRole;
+
+    @ApiProperty()
+    isMine: boolean;
 
     @ApiProperty()
     content: string;
@@ -24,5 +24,5 @@ export class ChatMessageResponseDto {
     isRead: boolean;
 
     @ApiProperty()
-    createdAt: Date;
+    createdAt: string;
 }

--- a/src/api/chat/dto/response/chat-room-response.dto.ts
+++ b/src/api/chat/dto/response/chat-room-response.dto.ts
@@ -1,15 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomStatus } from '../../../../schema/chat-room.schema';
+import { SenderRole } from '../../../../schema/chat-message.schema';
+
+export class ChatRoomCounterpartResponseDto {
+    @ApiProperty()
+    userId: string;
+
+    @ApiProperty({ enum: SenderRole })
+    role: SenderRole;
+
+    @ApiProperty()
+    nickname: string;
+
+    @ApiProperty({ required: false })
+    profileImageUrl?: string;
+}
 
 export class ChatRoomResponseDto {
     @ApiProperty()
     roomId: string;
-
-    @ApiProperty()
-    adopterId: string;
-
-    @ApiProperty()
-    breederId: string;
 
     @ApiProperty({ required: false })
     applicationId?: string;
@@ -17,12 +26,18 @@ export class ChatRoomResponseDto {
     @ApiProperty({ enum: ChatRoomStatus })
     status: ChatRoomStatus;
 
+    @ApiProperty({ type: ChatRoomCounterpartResponseDto })
+    counterpart: ChatRoomCounterpartResponseDto;
+
     @ApiProperty({ required: false })
     lastMessage?: string;
 
     @ApiProperty({ required: false })
-    lastMessageAt?: Date;
+    lastMessageAt?: string;
 
     @ApiProperty()
-    createdAt: Date;
+    unreadCount: number;
+
+    @ApiProperty()
+    createdAt: string;
 }

--- a/src/api/chat/infrastructure/chat-mongoose-manager.adapter.ts
+++ b/src/api/chat/infrastructure/chat-mongoose-manager.adapter.ts
@@ -72,4 +72,8 @@ export class ChatMongooseManagerAdapter implements ChatRoomManagerPort, ChatMess
     async markMessagesAsRead(roomId: string, receiverId: string): Promise<void> {
         await this.chatRepository.markMessagesAsRead(roomId, receiverId);
     }
+
+    async countUnreadMessages(roomId: string, receiverId: string): Promise<number> {
+        return this.chatRepository.countUnreadMessages(roomId, receiverId);
+    }
 }

--- a/src/api/chat/infrastructure/chat-participant-mongoose-reader.adapter.ts
+++ b/src/api/chat/infrastructure/chat-participant-mongoose-reader.adapter.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+import { Adopter, AdopterDocument } from '../../../schema/adopter.schema';
+import { Breeder, BreederDocument } from '../../../schema/breeder.schema';
+import { SenderRole } from '../../../schema/chat-message.schema';
+import { StorageService } from '../../../common/storage/storage.service';
+import {
+    ChatParticipantProfileSnapshot,
+    ChatParticipantReaderPort,
+} from '../application/ports/chat-participant-reader.port';
+
+@Injectable()
+export class ChatParticipantMongooseReaderAdapter implements ChatParticipantReaderPort {
+    constructor(
+        @InjectModel(Adopter.name) private readonly adopterModel: Model<AdopterDocument>,
+        @InjectModel(Breeder.name) private readonly breederModel: Model<BreederDocument>,
+        private readonly storageService: StorageService,
+    ) {}
+
+    async findProfile(userId: string, role: SenderRole): Promise<ChatParticipantProfileSnapshot | null> {
+        if (!Types.ObjectId.isValid(userId)) return null;
+
+        let user: { _id: Types.ObjectId; nickname?: string; name?: string; profileImageFileName?: string } | null;
+
+        if (role === SenderRole.BREEDER) {
+            user = await this.breederModel
+                .findById(userId)
+                .select({ nickname: 1, name: 1, profileImageFileName: 1 })
+                .lean<{ _id: Types.ObjectId; nickname?: string; name?: string; profileImageFileName?: string }>()
+                .exec();
+        } else {
+            user = await this.adopterModel
+                .findById(userId)
+                .select({ nickname: 1, profileImageFileName: 1 })
+                .lean<{ _id: Types.ObjectId; nickname?: string; profileImageFileName?: string }>()
+                .exec();
+        }
+
+        if (!user) return null;
+
+        return {
+            userId,
+            role,
+            nickname: user.name || user.nickname || '알 수 없음',
+            profileImageUrl: this.storageService.generateSignedUrlSafe(user.profileImageFileName, 60),
+        };
+    }
+}

--- a/src/api/chat/test/application/use-cases/get-messages.use-case.spec.ts
+++ b/src/api/chat/test/application/use-cases/get-messages.use-case.spec.ts
@@ -30,6 +30,7 @@ function makeMessageManager(messages: any[] = []): ChatMessageManagerPort {
         createMessage: jest.fn(),
         findMessagesByRoomId: jest.fn().mockResolvedValue(messages),
         markMessagesAsRead: jest.fn().mockResolvedValue(undefined),
+        countUnreadMessages: jest.fn().mockResolvedValue(0),
     };
 }
 

--- a/src/api/chat/test/application/use-cases/get-my-rooms.use-case.spec.ts
+++ b/src/api/chat/test/application/use-cases/get-my-rooms.use-case.spec.ts
@@ -15,21 +15,43 @@ function makeManager(adopterRooms: any[], breederRooms: any[]): ChatRoomManagerP
 }
 
 const logger = { logStart: jest.fn(), logSuccess: jest.fn(), logError: jest.fn() } as any;
+const assembler = {
+    toResults: jest.fn(async (rooms) =>
+        rooms.map((room: any) => ({
+            roomId: room.id,
+            status: room.status,
+            counterpart: { userId: 'counterpart-1', role: SenderRole.BREEDER, nickname: '상대방' },
+            unreadCount: 0,
+            createdAt: new Date().toISOString(),
+        })),
+    ),
+} as any;
 
 describe('GetMyRoomsUseCase', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('ADOPTER 역할: findRoomsByAdopterId', async () => {
         const manager = makeManager([{ id: 'a-room' }], []);
-        const useCase = new GetMyRoomsUseCase(manager, logger);
+        const useCase = new GetMyRoomsUseCase(manager, assembler, logger);
         const result = await useCase.execute('adopter-1', SenderRole.ADOPTER);
-        expect(result).toEqual([{ id: 'a-room' }]);
+        expect(result).toEqual([
+            expect.objectContaining({
+                roomId: 'a-room',
+                counterpart: expect.objectContaining({ nickname: '상대방' }),
+            }),
+        ]);
         expect(manager.findRoomsByAdopterId).toHaveBeenCalledWith('adopter-1');
+        expect(assembler.toResults).toHaveBeenCalledWith([{ id: 'a-room' }], 'adopter-1', SenderRole.ADOPTER);
     });
 
     it('BREEDER 역할: findRoomsByBreederId', async () => {
         const manager = makeManager([], [{ id: 'b-room' }]);
-        const useCase = new GetMyRoomsUseCase(manager, logger);
+        const useCase = new GetMyRoomsUseCase(manager, assembler, logger);
         const result = await useCase.execute('breeder-1', SenderRole.BREEDER);
-        expect(result).toEqual([{ id: 'b-room' }]);
+        expect(result).toEqual([expect.objectContaining({ roomId: 'b-room' })]);
         expect(manager.findRoomsByBreederId).toHaveBeenCalledWith('breeder-1');
+        expect(assembler.toResults).toHaveBeenCalledWith([{ id: 'b-room' }], 'breeder-1', SenderRole.BREEDER);
     });
 });

--- a/src/api/chat/test/application/use-cases/send-message.use-case.spec.ts
+++ b/src/api/chat/test/application/use-cases/send-message.use-case.spec.ts
@@ -45,6 +45,7 @@ function makeMessageManager(): ChatMessageManagerPort {
         createMessage: jest.fn().mockResolvedValue(message),
         findMessagesByRoomId: jest.fn(),
         markMessagesAsRead: jest.fn(),
+        countUnreadMessages: jest.fn().mockResolvedValue(0),
     };
 }
 

--- a/src/api/chat/test/chat.e2e-spec.ts
+++ b/src/api/chat/test/chat.e2e-spec.ts
@@ -71,11 +71,19 @@ describe('Chat API E2E Tests', () => {
                 .expect(200); // @HttpCode(200) 적용
 
             expect(response.body).toBeDefined();
-            expect(response.body.id).toBeDefined();
-            expect(response.body.adopterId).toBe(adopterId);
-            expect(response.body.breederId).toBe(breederId);
+            expect(response.body.roomId).toBeDefined();
+            expect(response.body.adopterId).toBeUndefined();
+            expect(response.body.breederId).toBeUndefined();
+            expect(response.body.counterpart).toEqual(
+                expect.objectContaining({
+                    userId: breederId,
+                    role: 'breeder',
+                    nickname: expect.any(String),
+                }),
+            );
+            expect(response.body.unreadCount).toBe(0);
 
-            roomId = response.body.id;
+            roomId = response.body.roomId;
             console.log('✅ 채팅방 생성 성공:', roomId);
         });
 
@@ -86,7 +94,7 @@ describe('Chat API E2E Tests', () => {
                 .send({ breederId })
                 .expect(200);
 
-            expect(response.body.id).toBe(roomId);
+            expect(response.body.roomId).toBe(roomId);
             console.log('✅ 기존 채팅방 반환 확인:', roomId);
         });
 
@@ -104,7 +112,8 @@ describe('Chat API E2E Tests', () => {
                 })
                 .expect(200);
 
-            expect(response.body.id).toBeDefined();
+            expect(response.body.roomId).toBeDefined();
+            expect(response.body.applicationId).toBe('test-application-id');
             console.log('✅ applicationId 포함 채팅방 생성 성공');
         });
 
@@ -149,7 +158,7 @@ describe('Chat API E2E Tests', () => {
                 .set('Authorization', `Bearer ${adopterToken}`)
                 .send({ breederId: anotherBreeder!.breederId })
                 .expect(200);
-            const firstRoomId = createRes.body.id;
+            const firstRoomId = createRes.body.roomId;
 
             // 채팅방 닫기
             await request(app.getHttpServer())
@@ -164,8 +173,8 @@ describe('Chat API E2E Tests', () => {
                 .send({ breederId: anotherBreeder!.breederId })
                 .expect(200);
 
-            expect(newRes.body.id).not.toBe(firstRoomId);
-            console.log('✅ 닫힌 방 이후 재요청 시 새 채팅방 생성 확인:', newRes.body.id);
+            expect(newRes.body.roomId).not.toBe(firstRoomId);
+            console.log('✅ 닫힌 방 이후 재요청 시 새 채팅방 생성 확인:', newRes.body.roomId);
         });
     });
 
@@ -189,7 +198,16 @@ describe('Chat API E2E Tests', () => {
 
             expect(Array.isArray(response.body)).toBe(true);
             expect(response.body.length).toBeGreaterThan(0);
-            expect(response.body[0].adopterId).toBe(adopterId);
+            expect(response.body[0].adopterId).toBeUndefined();
+            expect(response.body[0].breederId).toBeUndefined();
+            expect(response.body[0].counterpart).toEqual(
+                expect.objectContaining({
+                    userId: breederId,
+                    role: 'breeder',
+                    nickname: expect.any(String),
+                }),
+            );
+            expect(response.body[0].unreadCount).toEqual(expect.any(Number));
             console.log('✅ 입양자 채팅방 목록 조회 성공, 건수:', response.body.length);
         });
 
@@ -201,7 +219,15 @@ describe('Chat API E2E Tests', () => {
 
             expect(Array.isArray(response.body)).toBe(true);
             expect(response.body.length).toBeGreaterThan(0);
-            expect(response.body[0].breederId).toBe(breederId);
+            expect(response.body[0].adopterId).toBeUndefined();
+            expect(response.body[0].breederId).toBeUndefined();
+            expect(response.body[0].counterpart).toEqual(
+                expect.objectContaining({
+                    userId: adopterId,
+                    role: 'adopter',
+                    nickname: expect.any(String),
+                }),
+            );
             console.log('✅ 브리더 채팅방 목록 조회 성공, 건수:', response.body.length);
         });
 
@@ -223,7 +249,7 @@ describe('Chat API E2E Tests', () => {
                 .set('Authorization', `Bearer ${adopterToken}`)
                 .send({ breederId });
 
-            roomId = response.body.id;
+            roomId = response.body.roomId;
         });
 
         it('입양자가 채팅방 메시지 조회 성공 (빈 목록)', async () => {
@@ -307,7 +333,7 @@ describe('Chat API E2E Tests', () => {
                 .send({ breederId: freshBreeder!.breederId })
                 .expect(200);
 
-            roomId = response.body.id;
+            roomId = response.body.roomId;
 
             // 메시지 3개 직접 삽입
             const connection = app.get<Connection>(getConnectionToken());
@@ -359,10 +385,10 @@ describe('Chat API E2E Tests', () => {
                 .expect(200);
 
             const messages = response.body as Array<{
-                id: string;
+                messageId: string;
                 roomId: string;
-                senderId: string;
                 senderRole: string;
+                isMine: boolean;
                 content: string;
                 messageType: string;
                 isRead: boolean;
@@ -373,10 +399,11 @@ describe('Chat API E2E Tests', () => {
             expect(messages.length).toBe(3);
 
             const first = messages[0];
-            expect(first.id).toBeDefined();
+            expect(first.messageId).toBeDefined();
             expect(first.roomId).toBe(roomId);
-            expect(first.senderId).toBeDefined();
+            expect((first as any).senderId).toBeUndefined();
             expect(first.senderRole).toMatch(/adopter|breeder/);
+            expect(typeof first.isMine).toBe('boolean');
             expect(first.content).toBeDefined();
             expect(first.messageType).toBe('text');
             expect(typeof first.isRead).toBe('boolean');
@@ -420,7 +447,7 @@ describe('Chat API E2E Tests', () => {
                 .set('Authorization', `Bearer ${adopterToken}`)
                 .send({ breederId: anotherBreeder!.breederId });
 
-            roomId = response.body.id;
+            roomId = response.body.roomId;
         });
 
         it('입양자가 채팅방 닫기 성공', async () => {
@@ -441,7 +468,7 @@ describe('Chat API E2E Tests', () => {
                 .send({ breederId })
                 .expect(200);
 
-            const targetRoomId = (createRes.body as { id: string }).id;
+            const targetRoomId = (createRes.body as { roomId: string }).roomId;
 
             const response = await request(app.getHttpServer())
                 .delete(`/api/chat/rooms/${targetRoomId}`)


### PR DESCRIPTION
Closes #163

## 변경 사항
- 채팅방 응답 계약에 counterpart와 unreadCount 추가
- 메시지 응답 계약에 isMine 추가 및 senderId 노출 제거
- 채팅방 생성/조회/목록 API를 ChatRoomResult 조립 흐름으로 통일
- Adopter/Breeder 프로필 조회 어댑터와 응답 조립 서비스 추가
- 채팅 단위 테스트와 e2e 테스트를 새 응답 계약 기준으로 갱신

## 커밋 단위
- feat(chat): 화면용 채팅 응답 계약 추가
- feat(chat): 채팅 API 응답을 화면 계약으로 조립
- test(chat): 채팅 화면 응답 계약 검증 갱신

## 인수 조건 체크
- [x] 채팅방 목록/생성/조회 응답에서 프론트가 상대방 이름/이미지를 별도 계산하지 않는다.
- [x] 메시지 목록 응답에서 프론트가 내 메시지 여부를 senderId로 계산하지 않는다.
- [x] 채팅방 unreadCount가 백엔드에서 계산된다.
- [x] 기존 채팅 단위 테스트가 통과한다.
- [x] 채팅 e2e 테스트가 통과한다.

## 테스트 방법
1. `pnpm typecheck`
2. `pnpm test src/api/chat/test/application/use-cases/get-my-rooms.use-case.spec.ts src/api/chat/test/application/use-cases/get-messages.use-case.spec.ts src/api/chat/test/application/use-cases/send-message.use-case.spec.ts src/api/chat/test/domain/services/chat-room-mapper.service.spec.ts`
3. `pnpm test:e2e src/api/chat/test/chat.e2e-spec.ts`