### PR TITLE
feat(auth): 소셜 가입 완료 시 프로필 이미지 저장 (입양자·브리더)

### DIFF
--- a/src/api/auth/application/types/auth-signup.type.ts
+++ b/src/api/auth/application/types/auth-signup.type.ts
@@ -68,6 +68,7 @@ export type CompleteSocialRegistrationCommand = {
     phone?: string;
     marketingAgreed?: boolean;
     nickname?: string;
+    profileImage?: string;
     petType?: string;
     plan?: string;
     breederName?: string;

--- a/src/api/auth/application/use-cases/complete-social-registration.use-case.ts
+++ b/src/api/auth/application/use-cases/complete-social-registration.use-case.ts
@@ -48,6 +48,9 @@ export class CompleteSocialRegistrationUseCase {
             const breederDto: RegisterBreederAuthSignupCommand = {
                 tempId: dto.tempId,
                 provider: dto.provider,
+                // 입양자와 동일하게 사전 업로드한 프로필 이미지를 등록에 반영한다.
+                // (전달되지 않으면 register-breeder 가 tempId 임시저장소 값으로 폴백)
+                profileImage: dto.profileImage,
                 email: dto.email,
                 phoneNumber: dto.phone!,
                 breederName: dto.breederName!,

--- a/src/api/auth/application/use-cases/complete-social-registration.use-case.ts
+++ b/src/api/auth/application/use-cases/complete-social-registration.use-case.ts
@@ -35,6 +35,7 @@ export class CompleteSocialRegistrationUseCase {
                 email: dto.email,
                 nickname: dto.nickname!,
                 phone: dto.phone,
+                profileImage: dto.profileImage,
                 marketingAgreed: dto.marketingAgreed,
             };
 

--- a/src/api/auth/dto/request/social-complete-request.dto.ts
+++ b/src/api/auth/dto/request/social-complete-request.dto.ts
@@ -110,6 +110,19 @@ export class SocialCompleteRequestDto {
     nickname?: string;
 
     /**
+     * 프로필 이미지 (업로드 후 받은 파일명 또는 URL)
+     * @example "profiles/3f9c....jpg"
+     */
+    @ApiProperty({
+        description: '프로필 이미지 파일명 또는 URL (사전 업로드 후 전달)',
+        example: 'profiles/3f9c2b1a-....jpg',
+        required: false,
+    })
+    @IsString()
+    @IsOptional()
+    profileImage?: string;
+
+    /**
      * 브리딩 동물 종류 (브리더 전용)
      * @example "cat"
      */


### PR DESCRIPTION
## 변경 사항
- 소셜 신규 가입(`POST /api/v2/auth/social/complete`) 시 사전 업로드한 프로필 이미지를 등록에 반영
  - `SocialCompleteRequestDto`에 `profileImage` 필드 추가
  - `CompleteSocialRegistrationCommand`로 `profileImage` 전달
  - **입양자** 분기: `dto.profileImage` → 입양자 등록 반영
  - **브리더** 분기: `dto.profileImage` → 브리더 등록 반영 (기존 누락분 보완)

## 배경
브리더 소셜 가입 시 프로필 이미지가 저장되지 않는 문제를 로컬 통합 테스트에서 발견.
입양자 분기는 `dto.profileImage`를 등록 커맨드로 넘겼지만 **브리더 분기에서 누락**되어, 가입 직후 브리더 `profileImageFileName`이 빈 값으로 남았습니다.
(`register-breeder`에 `dto.profileImage || tempUploadInfo?.profileImage` 폴백이 있으나, `complete`에서 값을 직접 넘겨 프론트가 전송한 이미지가 확실히 반영되도록 정렬)

## 테스트
1. 입양자 소셜 가입 → 프로필 이미지 업로드 후 완료 → `GET /api/v2/profile/me`에 `profileImageUrl` 반환
2. 브리더 소셜 가입 → 프로필 이미지 업로드 후 완료 → MongoDB(dev) `breeders` 문서에 `profileImageFileName` 저장 확인, 마이홈 표시
