### PR TITLE
feat(profile): 브리더 프로필 수정·이미지 업로드 시 커뮤니티 작성자 snapshot 동기화

### DIFF
--- a/src/api/auth/application/use-cases/upload-auth-profile-image.use-case.ts
+++ b/src/api/auth/application/use-cases/upload-auth-profile-image.use-case.ts
@@ -1,5 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
+import {
+    USER_PROFILE_UPDATED_EVENT,
+    type UserProfileUpdatedEvent,
+} from '../../../../common/events/user-profile-updated.event';
 import { AUTH_TEMP_UPLOAD_PORT, type AuthTempUploadPort } from '../ports/auth-temp-upload.port';
 import {
     AUTH_PROFILE_IMAGE_TARGET_PORT,
@@ -30,6 +35,7 @@ export class UploadAuthProfileImageUseCase {
         @Inject(AUTH_TEMP_UPLOAD_PORT)
         private readonly authTempUploadPort: AuthTempUploadPort,
         private readonly authProfileImageFilePolicyService: AuthProfileImageFilePolicyService,
+        private readonly eventEmitter: EventEmitter2,
     ) {}
 
     async execute(
@@ -43,6 +49,14 @@ export class UploadAuthProfileImageUseCase {
 
         if (user && this.isSupportedRole(user.role)) {
             await this.authProfileImageTargetPort.save(user.userId, user.role, uploaded.fileName);
+
+            // 로그인 유저가 프로필 이미지를 교체하면 커뮤니티 등에 복제된 작성자 snapshot 을 동기화한다.
+            // 익명 가입(tempId 만 있는) 업로드는 여기 진입하지 않으므로 이벤트를 발행하지 않는다.
+            const payload: UserProfileUpdatedEvent = {
+                userId: user.userId,
+                profileImageFileName: uploaded.fileName,
+            };
+            this.eventEmitter.emit(USER_PROFILE_UPDATED_EVENT, payload);
         }
 
         if (tempId) {

--- a/src/api/auth/test/application/use-cases/upload-auth-profile-image.use-case.spec.ts
+++ b/src/api/auth/test/application/use-cases/upload-auth-profile-image.use-case.spec.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../../application/ports/auth-upload-file-store.port';
 import { AuthProfileImageFilePolicyService } from '../../../domain/services/auth-profile-image-file-policy.service';
 import { UploadAuthProfileImageUseCase } from '../../../application/use-cases/upload-auth-profile-image.use-case';
+import { USER_PROFILE_UPDATED_EVENT } from '../../../../../common/events/user-profile-updated.event';
 
 class StubAuthUploadFileStorePort implements AuthUploadFileStorePort {
     async upload(file: Express.Multer.File, folder: string): Promise<AuthUploadedStorageFile> {
@@ -64,16 +65,19 @@ class StubAuthTempUploadPort implements AuthTempUploadPort {
 describe('인증 프로필 이미지 업로드 유스케이스', () => {
     let targetPort: StubAuthProfileImageTargetPort;
     let tempUploadPort: StubAuthTempUploadPort;
+    let eventEmitter: { emit: jest.Mock };
     let useCase: UploadAuthProfileImageUseCase;
 
     beforeEach(() => {
         targetPort = new StubAuthProfileImageTargetPort();
         tempUploadPort = new StubAuthTempUploadPort();
+        eventEmitter = { emit: jest.fn() };
         useCase = new UploadAuthProfileImageUseCase(
             new StubAuthUploadFileStorePort(),
             targetPort,
             tempUploadPort,
             new AuthProfileImageFilePolicyService(),
+            eventEmitter as any,
         );
     });
 
@@ -98,6 +102,39 @@ describe('인증 프로필 이미지 업로드 유스케이스', () => {
         expect(tempUploadPort.get('temp-1')).toMatchObject({
             profileImage: 'profiles/profile.jpg',
         });
+        // 로그인 유저의 이미지 교체는 커뮤니티 작성자 snapshot 동기화 이벤트를 발행한다.
+        expect(eventEmitter.emit).toHaveBeenCalledWith(USER_PROFILE_UPDATED_EVENT, {
+            userId: 'user-id',
+            profileImageFileName: 'profiles/profile.jpg',
+        });
+    });
+
+    it('임시 ID만 있는 회원가입 업로드는 동기화 이벤트를 발행하지 않는다', async () => {
+        const file = {
+            originalname: 'profile.jpg',
+            size: 1024,
+        } as Express.Multer.File;
+
+        await useCase.execute(file, undefined, 'temp-1');
+
+        // 가입 전 임시 업로드는 유저 문서를 바꾸지 않으므로 이벤트 발행 대상이 아니다.
+        expect(targetPort.saved).toBeNull();
+        expect(eventEmitter.emit).not.toHaveBeenCalled();
+        expect(tempUploadPort.get('temp-1')).toMatchObject({
+            profileImage: 'profiles/profile.jpg',
+        });
+    });
+
+    it('지원하지 않는 role 은 저장과 이벤트를 모두 건너뛴다', async () => {
+        const file = {
+            originalname: 'profile.jpg',
+            size: 1024,
+        } as Express.Multer.File;
+
+        await useCase.execute(file, { userId: 'admin-id', role: 'admin' });
+
+        expect(targetPort.saved).toBeNull();
+        expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 
     it('100MB를 초과하면 기존 오류 계약을 유지한다', async () => {

--- a/src/api/breeder-management/application/use-cases/update-breeder-management-profile.use-case.ts
+++ b/src/api/breeder-management/application/use-cases/update-breeder-management-profile.use-case.ts
@@ -1,6 +1,11 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { DomainNotFoundError } from '../../../../common/error/domain.error';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
+import { DomainNotFoundError } from '../../../../common/error/domain.error';
+import {
+    USER_PROFILE_UPDATED_EVENT,
+    type UserProfileUpdatedEvent,
+} from '../../../../common/events/user-profile-updated.event';
 import { BREEDER_MANAGEMENT_PROFILE_PORT } from '../ports/breeder-management-profile.port';
 import type { BreederManagementProfilePort } from '../ports/breeder-management-profile.port';
 import { BreederManagementProfileCommandResultMapperService } from '../../domain/services/breeder-management-profile-command-result-mapper.service';
@@ -14,6 +19,7 @@ export class UpdateBreederManagementProfileUseCase {
         private readonly breederManagementProfilePort: BreederManagementProfilePort,
         private readonly breederManagementProfileUpdateMapperService: BreederManagementProfileUpdateMapperService,
         private readonly breederManagementProfileCommandResultMapperService: BreederManagementProfileCommandResultMapperService,
+        private readonly eventEmitter: EventEmitter2,
     ) {}
 
     async execute(userId: string, updateData: BreederManagementProfileUpdateCommand): Promise<{ message: string }> {
@@ -24,6 +30,16 @@ export class UpdateBreederManagementProfileUseCase {
 
         const mappedUpdateData = this.breederManagementProfileUpdateMapperService.toUpdateData(breeder, updateData);
         await this.breederManagementProfilePort.updateProfile(userId, mappedUpdateData);
+
+        // 닉네임/프로필 이미지는 커뮤니티 등에 snapshot 으로 복제돼 있어, 변경 시 동기화 이벤트를 발행한다.
+        // 저장된 필드와 발행 필드를 일치시키기 위해 원본 command 가 아닌 mappedUpdateData 에서 읽는다.
+        // (현재 이 경로는 profileImageFileName 만 변경 가능하지만, 향후 nickname 편집이 매퍼에 추가되면 자동 발행되도록 guard 는 제네릭하게 둔다.)
+        const nickname = mappedUpdateData.nickname as string | undefined;
+        const profileImageFileName = mappedUpdateData.profileImageFileName as string | undefined;
+        if (nickname !== undefined || profileImageFileName !== undefined) {
+            const payload: UserProfileUpdatedEvent = { userId, nickname, profileImageFileName };
+            this.eventEmitter.emit(USER_PROFILE_UPDATED_EVENT, payload);
+        }
 
         return this.breederManagementProfileCommandResultMapperService.toProfileUpdatedResult();
     }

--- a/src/api/breeder-management/test/application/use-cases/update-breeder-management-profile.use-case.spec.ts
+++ b/src/api/breeder-management/test/application/use-cases/update-breeder-management-profile.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { DomainNotFoundError } from '../../../../../common/error/domain.error';
+import { USER_PROFILE_UPDATED_EVENT } from '../../../../../common/events/user-profile-updated.event';
 
 import { UpdateBreederManagementProfileUseCase } from '../../../application/use-cases/update-breeder-management-profile.use-case';
 import { BreederManagementProfileUpdateMapperService } from '../../../domain/services/breeder-management-profile-update-mapper.service';
@@ -10,10 +11,13 @@ describe('브리더 프로필 수정 유스케이스', () => {
         updateProfile: jest.fn(),
     };
 
+    const eventEmitter = { emit: jest.fn() };
+
     const useCase = new UpdateBreederManagementProfileUseCase(
         breederManagementProfilePort as any,
         new BreederManagementProfileUpdateMapperService(),
         new BreederManagementProfileCommandResultMapperService(),
+        eventEmitter as any,
     );
 
     const mockBreeder = {
@@ -44,6 +48,8 @@ describe('브리더 프로필 수정 유스케이스', () => {
         expect(result.message).toBeDefined();
         expect(breederManagementProfilePort.findByIdWithAllData).toHaveBeenCalledWith('breeder-1');
         expect(breederManagementProfilePort.updateProfile).toHaveBeenCalledWith('breeder-1', expect.any(Object));
+        // 표시 정보(nickname/profileImageFileName) 변경이 없으면 동기화 이벤트를 발행하지 않는다.
+        expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 
     it('브리더를 찾을 수 없으면 도메인 not found 예외를 던진다', async () => {
@@ -54,5 +60,32 @@ describe('브리더 프로필 수정 유스케이스', () => {
             '브리더 정보를 찾을 수 없습니다.',
         );
         expect(breederManagementProfilePort.updateProfile).not.toHaveBeenCalled();
+        expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('프로필 이미지 변경 시 프로필 동기화 이벤트를 발행한다', async () => {
+        breederManagementProfilePort.findByIdWithAllData.mockResolvedValue(mockBreeder);
+        breederManagementProfilePort.updateProfile.mockResolvedValue(undefined);
+
+        await useCase.execute('breeder-1', { profileImage: 'profiles/new.png' } as any);
+
+        expect(eventEmitter.emit).toHaveBeenCalledWith(USER_PROFILE_UPDATED_EVENT, {
+            userId: 'breeder-1',
+            nickname: undefined,
+            profileImageFileName: 'profiles/new.png',
+        });
+    });
+
+    it('프로필 이미지 제거(빈 문자열) 시에도 동기화 이벤트를 발행한다', async () => {
+        breederManagementProfilePort.findByIdWithAllData.mockResolvedValue(mockBreeder);
+        breederManagementProfilePort.updateProfile.mockResolvedValue(undefined);
+
+        await useCase.execute('breeder-1', { profileImage: '' } as any);
+
+        expect(eventEmitter.emit).toHaveBeenCalledWith(USER_PROFILE_UPDATED_EVENT, {
+            userId: 'breeder-1',
+            nickname: undefined,
+            profileImageFileName: '',
+        });
     });
 });

--- a/src/api/breeder-management/test/e2e/breeder-profile-image-sync.e2e-spec.ts
+++ b/src/api/breeder-management/test/e2e/breeder-profile-image-sync.e2e-spec.ts
@@ -1,0 +1,99 @@
+import { INestApplication } from '@nestjs/common';
+import { getConnectionToken } from '@nestjs/mongoose';
+import { Connection, Types } from 'mongoose';
+import request from 'supertest';
+
+import { createTestingApp, getBreederToken } from '../../../../common/testing/test-utils';
+
+/**
+ * 브리더 프로필 이미지 변경 → 커뮤니티 작성자 snapshot 동기화 종단간(HTTP) 검증.
+ *
+ * controller(PATCH /v2/breeder-management/profile) → use-case → USER_PROFILE_UPDATED_EVENT emit
+ * → CommunityAuthorSyncListener → repository updateMany 까지 실제 앱/Mongo 로 확인한다.
+ * (adopter PATCH 경로와 동일한 이벤트를 브리더 경로에서도 발행하는지 보장한다.)
+ */
+describe('v2 브리더 프로필 이미지 변경 → 커뮤니티 snapshot 동기화 (HTTP)', () => {
+    let app: INestApplication;
+    let connection: Connection;
+    let token: string;
+    let breederId: string;
+
+    beforeAll(async () => {
+        app = await createTestingApp();
+        connection = app.get<Connection>(getConnectionToken());
+
+        const breeder = await getBreederToken(app);
+        if (!breeder) {
+            throw new Error('브리더 테스트 계정 생성 실패');
+        }
+        token = breeder.token;
+        breederId = breeder.breederId;
+    }, 30000);
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    beforeEach(async () => {
+        await connection.collection('community_posts').deleteMany({});
+    });
+
+    /** 로그인한 브리더가 작성한 것으로 게시글 snapshot 을 seed 한다. */
+    async function seedBreederPost(imageFile: string): Promise<Types.ObjectId> {
+        const _id = new Types.ObjectId();
+        await connection.collection('community_posts').insertOne({
+            _id,
+            authorId: new Types.ObjectId(breederId),
+            authorModel: 'Breeder',
+            authorNickname: '테스트브리더',
+            authorProfileImageFileName: imageFile,
+            body: '본문',
+            photos: [],
+            visibility: 'public',
+            status: 'published',
+            isActive: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        return _id;
+    }
+
+    /** 리스너(@OnEvent)는 emit 이후 비동기로 도므로 snapshot 이 기대값이 될 때까지 짧게 폴링한다. */
+    async function waitForSnapshotImage(postId: Types.ObjectId, expected: string): Promise<string | undefined> {
+        for (let attempt = 0; attempt < 40; attempt++) {
+            const post = await connection.collection('community_posts').findOne({ _id: postId });
+            if (post?.authorProfileImageFileName === expected) {
+                return post?.authorProfileImageFileName as string | undefined;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        const post = await connection.collection('community_posts').findOne({ _id: postId });
+        return post?.authorProfileImageFileName as string | undefined;
+    }
+
+    it('프로필 이미지를 바꾸면 내 게시글의 authorProfileImageFileName snapshot 이 갱신된다', async () => {
+        const postId = await seedBreederPost('old.png');
+
+        await request(app.getHttpServer())
+            .patch('/api/v2/breeder-management/profile')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ profileImage: 'profiles/new.png' })
+            .expect(200);
+
+        const synced = await waitForSnapshotImage(postId, 'profiles/new.png');
+        expect(synced).toBe('profiles/new.png');
+    });
+
+    it('프로필 이미지를 제거(빈 문자열)하면 snapshot 도 빈 문자열로 동기화된다', async () => {
+        const postId = await seedBreederPost('old.png');
+
+        await request(app.getHttpServer())
+            .patch('/api/v2/breeder-management/profile')
+            .set('Authorization', `Bearer ${token}`)
+            .send({ profileImage: '' })
+            .expect(200);
+
+        const synced = await waitForSnapshotImage(postId, '');
+        expect(synced).toBe('');
+    });
+});


### PR DESCRIPTION
## 변경 사항
- 프로필 표시 정보(닉네임/이미지) 변경 시 커뮤니티 작성자 snapshot 동기화 갭을 닫음 (기존 adopter PATCH 외 경로 보강)
  - 브리더 프로필 수정(`update-breeder-management-profile`): `profileImageFileName` 변경 시 `user.profile.updated` 이벤트 발행 (닉네임 포함 제네릭 guard로 향후 확장 대비)
  - 로그인 상태 프로필 이미지 업로드(`upload-auth-profile-image`): 인증 유저(adopter·breeder) 이미지 교체 시 이벤트 발행, `tempId` 익명 가입 업로드는 미발행
- 동기화 리스너/repository(`syncAuthorSnapshots`)는 `authorId` 기준 역할 무관 매칭이라 그대로 재사용

## 배경
프로필에서 닉네임은 동기화되는데 프로필 사진은 옛 값으로 남는 문제를 로컬 통합 테스트에서 발견.
adopter PATCH `/profile` 경로만 `user.profile.updated` 이벤트를 발행하고, 브리더 프로필 수정과 프로필 이미지 업로드 경로는 유저 문서만 갱신하고 이벤트를 발행하지 않아 커뮤니티 작성자 snapshot 이 갱신되지 않던 갭.

## 테스트
1. `pnpm typecheck` 통과
2. `pnpm test`(유닛 1636건) 통과
3. 유닛 스펙 보강: 브리더 프로필 이미지 변경/제거 발행, 이미지 업로드 로그인 발행·`tempId` 미발행·미지원 role 미발행
4. e2e 추가(`breeder-profile-image-sync.e2e-spec.ts`): 실제 PATCH `/v2/breeder-management/profile` → 이벤트 → snapshot 갱신(이미지 변경·제거) 검증
