### PR TITLE
feat(auth): 입양자 가입 시 공개 프로필 소개 저장

### DIFF
--- a/src/api/service/auth/application/types/auth-signup-register.type.ts
+++ b/src/api/service/auth/application/types/auth-signup-register.type.ts
@@ -17,6 +17,7 @@ export type CounselDefaultProfileInput = {
  * v2 입양자 가입 커맨드
  * v1 RegisterAdopterAuthSignupCommand 대비 추가 필드:
  * - realName: 온보딩4 실명
+ * - bio: 다른 사용자에게 공개되는 프로필 한 줄 소개
  * - interestedBreedIds: 온보딩3 관심 품종 ID 배열
  * - counselDefaultProfile: 온보딩4 상담 사전 정보
  * - termsAgreements: 온보딩2 약관 동의 이력 (활성 버전 기준)
@@ -28,6 +29,7 @@ export type RegisterAdopterCommand = {
     tempId: string;
     email: string;
     nickname: string;
+    bio?: string;
     phone?: string;
     profileImage?: string;
     realName: string;

--- a/src/api/service/auth/application/use-cases/register-adopter.use-case.ts
+++ b/src/api/service/auth/application/use-cases/register-adopter.use-case.ts
@@ -14,6 +14,8 @@ import { AuthPhoneNumberNormalizerService } from '../../domain/services/auth-pho
 import { AuthSignupResultMapperService } from '../../domain/services/auth-signup-result-mapper.service';
 import { AuthSignupValidationService } from '../../domain/services/auth-signup-validation.service';
 import { AuthTermsAgreementValidatorService } from '../../domain/services/auth-terms-agreement-validator.service';
+
+const BIO_MAX_LENGTH = 200;
 import type { RegisterAdopterCommand, RegisterAdopterResult } from '../types/auth-signup-register.type';
 
 @Injectable()
@@ -37,6 +39,11 @@ export class RegisterAdopterUseCase {
 
     async execute(command: RegisterAdopterCommand): Promise<RegisterAdopterResult> {
         const { provider, providerId } = this.authSocialIdentityService.parseRequiredTempId(command.tempId);
+
+        const bio = command.bio?.trim();
+        if (bio && bio.length > BIO_MAX_LENGTH) {
+            throw new BadRequestException(`한 줄 소개는 ${BIO_MAX_LENGTH}자 이내여야 합니다.`);
+        }
 
         const existingAdopter = await this.authRegistrationPort.findAdopterBySocialAuth(provider, providerId);
         this.authSignupValidationService.assertAdopterSocialAccountAvailable(existingAdopter);
@@ -67,6 +74,7 @@ export class RegisterAdopterUseCase {
         const savedAdopter = await this.authRegistrationPort.createAdopter({
             emailAddress: command.email,
             nickname: command.nickname,
+            ...(bio !== undefined ? { bio } : {}),
             phoneNumber: this.authPhoneNumberNormalizerService.normalize(command.phone),
             profileImageFileName: this.authStoredFileNameService.extract(command.profileImage) || '',
             socialAuthInfo: {

--- a/src/api/service/auth/dto/request/register-adopter-full-request.dto.ts
+++ b/src/api/service/auth/dto/request/register-adopter-full-request.dto.ts
@@ -9,6 +9,7 @@ import {
     IsNotEmpty,
     IsOptional,
     IsString,
+    MaxLength,
     ValidateNested,
 } from 'class-validator';
 
@@ -67,6 +68,17 @@ export class RegisterAdopterFullRequestDto {
     @IsString()
     @IsNotEmpty()
     nickname: string;
+
+    @ApiProperty({
+        description: '공개 프로필 한 줄 소개 (trim 후 최대 200자)',
+        example: '반려동물을 사랑하며 좋은 가족을 기다리고 있어요.',
+        required: false,
+        maxLength: 200,
+    })
+    @IsString()
+    @MaxLength(200)
+    @IsOptional()
+    bio?: string;
 
     @ApiProperty({ description: '실명 (상담 시 표시)', example: '홍길동' })
     @IsString()

--- a/src/api/service/auth/test/application/use-cases/register-adopter.use-case.spec.ts
+++ b/src/api/service/auth/test/application/use-cases/register-adopter.use-case.spec.ts
@@ -141,6 +141,30 @@ describe('v2 입양자 회원가입 유스케이스', () => {
         expect(authRegistrationPort.createAdopter).not.toHaveBeenCalled();
     });
 
+    it('공개 프로필 소개를 trim 하여 bio 로 저장한다', async () => {
+        await useCase.execute({
+            ...baseCommand,
+            bio: '  반려동물을 사랑하며 좋은 가족을 기다리고 있어요.  ',
+        });
+
+        expect(authRegistrationPort.createAdopter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bio: '반려동물을 사랑하며 좋은 가족을 기다리고 있어요.',
+            }),
+        );
+    });
+
+    it('공개 프로필 소개가 200자를 초과하면 가입에 실패한다', async () => {
+        await expect(
+            useCase.execute({
+                ...baseCommand,
+                bio: '가'.repeat(201),
+            }),
+        ).rejects.toThrow('한 줄 소개는 200자 이내여야 합니다.');
+
+        expect(authRegistrationPort.createAdopter).not.toHaveBeenCalled();
+    });
+
     it('marketing 동의가 termsAgreements 에 없으면 marketingAgreed=false 로 저장 (클라 boolean spoof 차단)', async () => {
         await useCase.execute(baseCommand);
 


### PR DESCRIPTION
## 변경 사항
- 입양자 가입 DTO에 선택 필드 bio 추가
- 공개 프로필 소개를 trim 후 Adopter.bio에 저장
- 최대 200자 검증 및 관련 단위 테스트 추가